### PR TITLE
Fix srt listen callback setting

### DIFF
--- a/c_src/ex_libsrt/server/server.cpp
+++ b/c_src/ex_libsrt/server/server.cpp
@@ -44,7 +44,6 @@ void Server::Run(const char* address, int port) {
   const int read_modes = SRT_EPOLL_IN | SRT_EPOLL_ERR;
   srt_epoll_add_usock(epoll, srt_sock, &read_modes);
 
-
   running.store(true);
 
   epoll_loop = std::thread(&Server::RunEpoll, this);

--- a/c_src/ex_libsrt/server/server.cpp
+++ b/c_src/ex_libsrt/server/server.cpp
@@ -28,6 +28,9 @@ void Server::Run(const char* address, int port) {
     throw std::runtime_error(std::string(srt_getlasterror_str()));
   }
 
+  srt_listen_callback(srt_sock,
+                      (srt_listen_callback_fn*)&Server::ListenAcceptCallback,
+                      (void*)this);
   srt_bind_sock = srt_listen(srt_sock, MAX_PENDING_CONNECTIONS);
   if (srt_bind_sock == SRT_ERROR) {
     throw std::runtime_error(std::string(srt_getlasterror_str()));
@@ -41,9 +44,6 @@ void Server::Run(const char* address, int port) {
   const int read_modes = SRT_EPOLL_IN | SRT_EPOLL_ERR;
   srt_epoll_add_usock(epoll, srt_sock, &read_modes);
 
-  srt_listen_callback(srt_sock,
-                      (srt_listen_callback_fn*)&Server::ListenAcceptCallback,
-                      (void*)this);
 
   running.store(true);
 

--- a/examples/server.exs
+++ b/examples/server.exs
@@ -1,5 +1,4 @@
-Mix.install([{:ex_libsrt, path: "../ex_libsrt"}])
-
+Mix.install([{:ex_libsrt, path: "../"}])
 
 defmodule Server do
   use GenServer
@@ -19,7 +18,9 @@ defmodule Server do
 
   @impl true
   def handle_info({:srt_server_connect_request, address, stream_id}, state) do
-    Logger.info("Receiving new connection request with stream id: #{stream_id} from address: #{address}")
+    Logger.info(
+      "Receiving new connection request with stream id: #{stream_id} from address: #{address}"
+    )
 
     :ok = ExLibSRT.Server.accept_awaiting_connect_request(state.server)
 
@@ -64,14 +65,10 @@ receive do
 end
 
 # Process.sleep(2_000)
-#
 for _i <- 1..10_000 do
   payload = :crypto.strong_rand_bytes(1200)
-
   :ok = ExLibSRT.Client.send_data(payload, client)
 end
-
-
 
 Process.sleep(5000)
 
@@ -80,4 +77,3 @@ ExLibSRT.Client.stop(client)
 Process.sleep(1000)
 
 GenServer.stop(server)
-


### PR DESCRIPTION
This PR:
* Fixes order in which srt listen callback is set and when `srt_listen` is invoked. 
* Fixes path to `ex_libsrt` in `examples/server.cpp`