### PR TITLE
Fix segfault. Allow for empty epoll. Bump to v0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The package exposes a server and a client module to interact with SRT streams.
 ```elixir
 def deps do
   [
-    {:ex_libsrt, "~> 0.1.1"}
+    {:ex_libsrt, "~> 0.1.2"}
   ]
 end
 ```

--- a/c_src/ex_libsrt/server/server.cpp
+++ b/c_src/ex_libsrt/server/server.cpp
@@ -80,6 +80,10 @@ void Server::CloseConnection(int connection_id) {
 }
 
 void Server::RunEpoll() {
+  // Setting this one prevents spamming with "no sockets to check, this would deadlock" logs during closing
+  // of the system, when there are no sockets in the epoll anymore
+  srt_epoll_set(epoll, SRT_EPOLL_ENABLE_EMPTY);
+
   int sockets_len = 100;
   SrtSocket sockets[sockets_len];
 

--- a/c_src/ex_libsrt/srt_nif.cpp
+++ b/c_src/ex_libsrt/srt_nif.cpp
@@ -145,7 +145,7 @@ UNIFEX_TERM start_server(UnifexEnv* env, char* address, int port, char* password
     state->server->SetOnSocketData(
         [=](Server::SrtSocket socket, const char* data, int len) {
           UnifexPayload* payload =
-              (UnifexPayload*)unifex_alloc(sizeof(UnifexPayload*));
+              (UnifexPayload*)unifex_alloc(sizeof(UnifexPayload));
 
           unifex_payload_alloc(state->env, UNIFEX_PAYLOAD_BINARY, len, payload);
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExLibSRT.MixProject do
   use Mix.Project
 
-  @version "0.1.1"
+  @version "0.1.2"
   @github_url "https://github.com/membraneframework/ex_libsrt"
 
   def project do


### PR DESCRIPTION
This PR:
* Fixes a bug with allocating memory for the UnifexPayload pointer instead of an actual UnifexPayload. 
* Sets the flag allowing for an empty epoll
* Bumps version to v0.1.2