### PR TITLE
Add server send API and receiver-mode native client for caller-side ingest

### DIFF
--- a/PR.md
+++ b/PR.md
@@ -1,0 +1,59 @@
+# Add missing data-path support for caller-side ingest (server send + client receive)
+
+## Problem
+
+`ex_libsrt` was missing two capabilities needed by downstream caller-side ingest workflows:
+
+1. Server could accept/receive, but had no API to send payloads back through an active connection.
+2. Client startup was effectively sender-only in public usage, so caller-mode ingest could connect but not receive media.
+
+## Changes
+
+### 1) Server-side send support
+
+- Native API: `ExLibSRT.Native.send_server_data(conn_id, payload, server_ref)`
+- Public API: `ExLibSRT.Server.send_data(connection_id, payload, server_pid)`
+
+Behavior:
+- validates active server and connection
+- sends via `srt_sendmsg`
+- returns `:ok | {:error, reason}`
+- enforces max payload size (`1316`) in `Server.send_data/3`
+
+### 2) Receiver-mode client data path
+
+- client mode controls `SRTO_SENDER`
+- receiver mode enables `SRT_EPOLL_IN`
+- receiver mode reads with `srt_recv`
+- emits `{:srt_data, 0, payload}`
+- `send_client_data/2` returns `{:error, "Client is not in sender mode"}` in receiver mode
+
+### 3) Public API shape (developer-facing)
+
+- public mode is atom-based: `:sender | :receiver`
+- public entrypoints:
+  - `ExLibSRT.Native.start_client/5` (default sender)
+  - `ExLibSRT.Native.start_client/6` (explicit mode)
+  - `ExLibSRT.Client.start/4` and `start_link/4` with options (`mode`, `password`, `latency_ms`)
+- integer flag is internal-only via native entrypoint `start_client_native/6`
+- `start_client_with_mode/6` is not exposed publicly
+
+## Compatibility
+
+- sender remains the default
+- existing positional `Client.start/...` and `start_link/...` calls still work
+- no expected break for published users
+
+## Tests
+
+- server send path tests (`Server.send_data/3`, payload size)
+- coop test verifies receiver-mode client receives server payload
+- receiver-mode send rejection verified
+- options validation tests added
+- full suite passes: `mix test`
+
+## Recommended version bump
+
+**Minor** (`0.1.6 -> 0.2.0`).
+
+Reason: this PR adds new public capabilities/API surface while keeping published behavior backward compatible.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,27 @@ To see how to handle multiple client connections with a single server using
 
 To send payloads from server to a connected client, use `ExLibSRT.Server.send_data/3`.
 
+## Client modes (`:sender` / `:receiver`)
+
+`ExLibSRT.Client` supports explicit client socket mode via options:
+
+```elixir
+# default mode is :sender
+{:ok, client} = ExLibSRT.Client.start("127.0.0.1", 12_000, "stream-id")
+
+# receiver mode (can receive `{:srt_data, conn_id, payload}` messages)
+{:ok, client} =
+  ExLibSRT.Client.start("127.0.0.1", 12_000, "stream-id", mode: :receiver)
+
+# with password and latency
+{:ok, client} =
+  ExLibSRT.Client.start("127.0.0.1", 12_000, "stream-id",
+    password: "validpassword123",
+    latency_ms: 120,
+    mode: :receiver
+  )
+```
+
 You can launch each of these scripts with the following sequence of commands:
 ```
 cd examples/

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ To send payloads from server to a connected client, use `ExLibSRT.Server.send_da
 
 ## Client modes (`:sender` / `:receiver`)
 
-`ExLibSRT.Client` supports explicit client socket mode via options:
+`ExLibSRT.Client` supports explicit client socket mode via options.
+The API is atom-based (`:sender | :receiver`) and does not expose raw integer mode flags:
 
 ```elixir
 # default mode is :sender

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ see: `simple_client_connection.exs`.
 To see how to handle multiple client connections with a single server using 
 `ExLibSRT.Connection.Handler`, see: `connection_handler.exs`.
 
+To send payloads from server to a connected client, use `ExLibSRT.Server.send_data/3`.
+
 You can launch each of these scripts with the following sequence of commands:
 ```
 cd examples/

--- a/c_src/ex_libsrt/client/client.cpp
+++ b/c_src/ex_libsrt/client/client.cpp
@@ -19,7 +19,11 @@ void Client::Run(const std::string& address,
                  int port,
                  const std::string& stream_id,
                  const std::string& password,
-                 int latency_ms) {
+                 int latency_ms,
+                 int rcvbuf,
+                 int udp_rcvbuf,
+                 int sndbuf,
+                 int udp_sndbuf) {
   this->password = password;
 
   struct sockaddr_storage ss;
@@ -75,6 +79,30 @@ void Client::Run(const std::string& address,
 
   if (latency_ms >= 0) {
     if (srt_setsockflag(srt_sock, SRTO_LATENCY, &latency_ms, sizeof latency_ms) == SRT_ERROR) {
+      throw std::runtime_error(std::string(srt_getlasterror_str()));
+    }
+  }
+
+  if (rcvbuf >= 0) {
+    if (srt_setsockflag(srt_sock, SRTO_RCVBUF, &rcvbuf, sizeof rcvbuf) == SRT_ERROR) {
+      throw std::runtime_error(std::string(srt_getlasterror_str()));
+    }
+  }
+
+  if (udp_rcvbuf >= 0) {
+    if (srt_setsockflag(srt_sock, SRTO_UDP_RCVBUF, &udp_rcvbuf, sizeof udp_rcvbuf) == SRT_ERROR) {
+      throw std::runtime_error(std::string(srt_getlasterror_str()));
+    }
+  }
+
+  if (sndbuf >= 0) {
+    if (srt_setsockflag(srt_sock, SRTO_SNDBUF, &sndbuf, sizeof sndbuf) == SRT_ERROR) {
+      throw std::runtime_error(std::string(srt_getlasterror_str()));
+    }
+  }
+
+  if (udp_sndbuf >= 0) {
+    if (srt_setsockflag(srt_sock, SRTO_UDP_SNDBUF, &udp_sndbuf, sizeof udp_sndbuf) == SRT_ERROR) {
       throw std::runtime_error(std::string(srt_getlasterror_str()));
     }
   }

--- a/c_src/ex_libsrt/client/client.cpp
+++ b/c_src/ex_libsrt/client/client.cpp
@@ -267,16 +267,18 @@ void Client::RunEpoll() {
         }
 
         if (!sender_mode && socket_state == SRTS_CONNECTED) {
-          // Drain up to max_read_per_cycle packets per epoll cycle
-          // to deplete the SRT receive buffer before returning to
-          // epoll_wait.  Mirrors srt-live-transmit's batched-read
-          // strategy.  Each packet is delivered as its own callback
-          // to preserve per-message semantics for consumers.
-          bool got_any = false;
+          // Drain up to max_read_per_cycle packets per epoll cycle,
+          // coalescing into a single buffer to minimize NIF→BEAM
+          // crossings.  Mirrors srt-live-transmit's batched-read
+          // strategy ("deplete read buffers as much as possible on
+          // each read event").
+          char batch_buf[max_read_per_cycle * 1500];
+          int  batch_len = 0;
 
           for (int i = 0; i < max_read_per_cycle; ++i) {
-            char buffer[1500];
-            int bytes_read = srt_recv(read_socket, buffer, sizeof(buffer));
+            int bytes_read = srt_recv(read_socket,
+                                      batch_buf + batch_len,
+                                      sizeof(batch_buf) - batch_len);
 
             if (bytes_read == SRT_ERROR) {
               if (srt_getlasterror(nullptr) == SRT_EASYNCRCV) {
@@ -299,14 +301,10 @@ void Client::RunEpoll() {
               break;
             }
 
-            got_any = true;
-
-            if (on_socket_data) {
-              on_socket_data(buffer, bytes_read);
-            }
+            batch_len += bytes_read;
           }
 
-          if (!got_any) {
+          if (batch_len == 0) {
             // No data despite read-ready — connection lost.
             running.store(false);
             send_cv.notify_all();
@@ -316,6 +314,10 @@ void Client::RunEpoll() {
             }
 
             return;
+          }
+
+          if (on_socket_data) {
+            on_socket_data(batch_buf, batch_len);
           }
         }
       }

--- a/c_src/ex_libsrt/client/client.cpp
+++ b/c_src/ex_libsrt/client/client.cpp
@@ -267,11 +267,47 @@ void Client::RunEpoll() {
         }
 
         if (!sender_mode && socket_state == SRTS_CONNECTED) {
-          char buffer[1500];
+          // Drain up to max_read_per_cycle packets per epoll cycle
+          // to deplete the SRT receive buffer before returning to
+          // epoll_wait.  Mirrors srt-live-transmit's batched-read
+          // strategy.  Each packet is delivered as its own callback
+          // to preserve per-message semantics for consumers.
+          bool got_any = false;
 
-          int bytes_read = srt_recv(read_socket, buffer, sizeof(buffer));
+          for (int i = 0; i < max_read_per_cycle; ++i) {
+            char buffer[1500];
+            int bytes_read = srt_recv(read_socket, buffer, sizeof(buffer));
 
-          if (bytes_read == 0 || bytes_read == SRT_ERROR) {
+            if (bytes_read == SRT_ERROR) {
+              if (srt_getlasterror(nullptr) == SRT_EASYNCRCV) {
+                // No more data available right now — buffer drained.
+                break;
+              }
+
+              // Real error — treat as disconnect.
+              running.store(false);
+              send_cv.notify_all();
+
+              if (on_socket_disconnected) {
+                on_socket_disconnected();
+              }
+
+              return;
+            }
+
+            if (bytes_read == 0) {
+              break;
+            }
+
+            got_any = true;
+
+            if (on_socket_data) {
+              on_socket_data(buffer, bytes_read);
+            }
+          }
+
+          if (!got_any) {
+            // No data despite read-ready — connection lost.
             running.store(false);
             send_cv.notify_all();
 
@@ -280,10 +316,6 @@ void Client::RunEpoll() {
             }
 
             return;
-          }
-
-          if (on_socket_data) {
-            on_socket_data(buffer, bytes_read);
           }
         }
       }

--- a/c_src/ex_libsrt/client/client.cpp
+++ b/c_src/ex_libsrt/client/client.cpp
@@ -127,10 +127,14 @@ void Client::Run(const std::string& address,
     throw std::runtime_error(std::string(srt_getlasterror_str()));
   }
 
-  int poll_modes = SRT_EPOLL_OUT | SRT_EPOLL_ERR;
+  // Receiver mode needs OUT only until connect transition is observed.
+  // After connection we switch to IN|ERR only to avoid constant writable wakeups.
+  int poll_modes = SRT_EPOLL_ERR;
 
-  if (!sender_mode) {
-    poll_modes |= SRT_EPOLL_IN;
+  if (sender_mode) {
+    poll_modes |= SRT_EPOLL_OUT;
+  } else {
+    poll_modes |= SRT_EPOLL_IN | SRT_EPOLL_OUT;
   }
 
   if (srt_epoll_add_usock(epoll, srt_sock, &poll_modes) == SRT_ERROR) {
@@ -237,8 +241,17 @@ void Client::RunEpoll() {
         continue;
       }
 
-      if (write_len > 0 && !connected) {
+      auto socket_state = srt_getsockstate(srt_sock);
+
+      if (!connected && (write_len > 0 || socket_state == SRTS_CONNECTED)) {
         connected = true;
+
+        if (!sender_mode) {
+          const int receiver_modes = SRT_EPOLL_IN | SRT_EPOLL_ERR;
+          if (srt_epoll_update_usock(epoll, srt_sock, &receiver_modes) == SRT_ERROR) {
+            throw std::runtime_error(std::string(srt_getlasterror_str()));
+          }
+        }
 
         if (on_socket_connected) {
           on_socket_connected();
@@ -246,7 +259,7 @@ void Client::RunEpoll() {
       }
 
       if (read_len > 0) {
-        auto socket_state = srt_getsockstate(read_socket);
+        socket_state = srt_getsockstate(read_socket);
 
         if (!connected && socket_state == SRTS_BROKEN) {
           int code = srt_getrejectreason(read_socket);

--- a/c_src/ex_libsrt/client/client.h
+++ b/c_src/ex_libsrt/client/client.h
@@ -26,8 +26,8 @@ public:
   };
     
 
-  Client(int max_pending_messages, int send_ttl)
-      : max_pending_messages(max_pending_messages), send_ttl(send_ttl) {}
+  Client(int max_pending_messages, int send_ttl, bool sender_mode = true)
+      : max_pending_messages(max_pending_messages), send_ttl(send_ttl), sender_mode(sender_mode) {}
 
   ~Client();
 
@@ -53,6 +53,10 @@ public:
     this->on_socket_disconnected = std::move(on_socket_disconnected);
   }
 
+  void SetOnSocketData(std::function<void(const char*, int)>&& on_socket_data) {
+    this->on_socket_data = std::move(on_socket_data);
+  }
+
 private:
   void RunEpoll();
   void SendFromQueue();
@@ -70,10 +74,12 @@ private:
   std::function<void(const std::string&)> on_socket_error;
   std::function<void()> on_socket_connected;
   std::function<void()> on_socket_disconnected;
+  std::function<void(const char*, int)> on_socket_data;
 
 private:
   const int max_pending_messages;
   const int send_ttl;
+  const bool sender_mode;
 
   std::mutex send_mutex;
   std::condition_variable send_cv;

--- a/c_src/ex_libsrt/client/client.h
+++ b/c_src/ex_libsrt/client/client.h
@@ -85,6 +85,11 @@ private:
   const int send_ttl;
   const bool sender_mode;
 
+  // Maximum number of SRT packets drained per epoll read-ready cycle.
+  // Mirrors srt-live-transmit's "buffering" strategy to deplete the
+  // SRT receive buffer before returning to epoll_wait.
+  static constexpr int max_read_per_cycle = 20;
+
   std::mutex send_mutex;
   std::condition_variable send_cv;
   std::deque<std::pair<std::unique_ptr<char[]>, int>> send_queue;

--- a/c_src/ex_libsrt/client/client.h
+++ b/c_src/ex_libsrt/client/client.h
@@ -88,7 +88,7 @@ private:
   // Maximum number of SRT packets drained per epoll read-ready cycle.
   // Mirrors srt-live-transmit's "buffering" strategy to deplete the
   // SRT receive buffer before returning to epoll_wait.
-  static constexpr int max_read_per_cycle = 20;
+  static constexpr int max_read_per_cycle = 100;
 
   std::mutex send_mutex;
   std::condition_variable send_cv;

--- a/c_src/ex_libsrt/client/client.h
+++ b/c_src/ex_libsrt/client/client.h
@@ -35,7 +35,11 @@ public:
            int port,
            const std::string& stream_id,
            const std::string& password = "",
-           int latency_ms = -1);
+           int latency_ms = -1,
+           int rcvbuf = -1,
+           int udp_rcvbuf = -1,
+           int sndbuf = -1,
+           int udp_sndbuf = -1);
   void Send(std::unique_ptr<char[]> data, int len);
   std::unique_ptr<SrtSocketStats> ReadSocketStats(bool clear_intervals);
   void Stop();

--- a/c_src/ex_libsrt/server/server.cpp
+++ b/c_src/ex_libsrt/server/server.cpp
@@ -10,7 +10,11 @@
 void Server::Run(const std::string& address,
                  int port,
                  const std::string& password,
-                 int latency_ms) {
+                 int latency_ms,
+                 int rcvbuf,
+                 int udp_rcvbuf,
+                 int sndbuf,
+                 int udp_sndbuf) {
   this->password = password;
   this->latency_ms = latency_ms;
 
@@ -54,6 +58,30 @@ void Server::Run(const std::string& address,
   srt_setsockflag(srt_sock, SRTO_STREAMID, &yes, sizeof yes);
   if (latency_ms >= 0) {
     if (srt_setsockflag(srt_sock, SRTO_LATENCY, &latency_ms, sizeof latency_ms) == SRT_ERROR) {
+      throw std::runtime_error(std::string(srt_getlasterror_str()));
+    }
+  }
+
+  if (rcvbuf >= 0) {
+    if (srt_setsockflag(srt_sock, SRTO_RCVBUF, &rcvbuf, sizeof rcvbuf) == SRT_ERROR) {
+      throw std::runtime_error(std::string(srt_getlasterror_str()));
+    }
+  }
+
+  if (udp_rcvbuf >= 0) {
+    if (srt_setsockflag(srt_sock, SRTO_UDP_RCVBUF, &udp_rcvbuf, sizeof udp_rcvbuf) == SRT_ERROR) {
+      throw std::runtime_error(std::string(srt_getlasterror_str()));
+    }
+  }
+
+  if (sndbuf >= 0) {
+    if (srt_setsockflag(srt_sock, SRTO_SNDBUF, &sndbuf, sizeof sndbuf) == SRT_ERROR) {
+      throw std::runtime_error(std::string(srt_getlasterror_str()));
+    }
+  }
+
+  if (udp_sndbuf >= 0) {
+    if (srt_setsockflag(srt_sock, SRTO_UDP_SNDBUF, &udp_sndbuf, sizeof udp_sndbuf) == SRT_ERROR) {
       throw std::runtime_error(std::string(srt_getlasterror_str()));
     }
   }

--- a/c_src/ex_libsrt/server/server.cpp
+++ b/c_src/ex_libsrt/server/server.cpp
@@ -5,6 +5,7 @@
 #include <exception>
 #include <string>
 #include <vector>
+
 #include <unifex/unifex.h>
 
 void Server::Run(const std::string& address,
@@ -25,8 +26,8 @@ void Server::Run(const std::string& address,
   int af;
   memset(&ss, 0, sizeof(ss));
 
-  struct sockaddr_in6 *sa6 = reinterpret_cast<struct sockaddr_in6*>(&ss);
-  struct sockaddr_in  *sa4 = reinterpret_cast<struct sockaddr_in*>(&ss);
+  struct sockaddr_in6* sa6 = reinterpret_cast<struct sockaddr_in6*>(&ss);
+  struct sockaddr_in* sa4 = reinterpret_cast<struct sockaddr_in*>(&ss);
 
   if (inet_pton(AF_INET6, address.c_str(), &sa6->sin6_addr) == 1) {
     sa6->sin6_family = AF_INET6;
@@ -51,51 +52,60 @@ void Server::Run(const std::string& address,
   int no = 0;
 
   if (af == AF_INET6) {
-    if (srt_setsockflag(srt_sock, SRTO_IPV6ONLY, &yes, sizeof yes) == SRT_ERROR) {
-        throw std::runtime_error(std::string(srt_getlasterror_str()));
+    if (srt_setsockflag(srt_sock, SRTO_IPV6ONLY, &yes, sizeof yes) ==
+        SRT_ERROR) {
+      throw std::runtime_error(std::string(srt_getlasterror_str()));
     }
   }
 
   srt_setsockflag(srt_sock, SRTO_RCVSYN, &no, sizeof yes);
   srt_setsockflag(srt_sock, SRTO_SNDSYN, &no, sizeof yes);
   srt_setsockflag(srt_sock, SRTO_STREAMID, &yes, sizeof yes);
+
   if (latency_ms >= 0) {
-    if (srt_setsockflag(srt_sock, SRTO_LATENCY, &latency_ms, sizeof latency_ms) == SRT_ERROR) {
+    if (srt_setsockflag(srt_sock, SRTO_LATENCY, &latency_ms,
+                        sizeof latency_ms) == SRT_ERROR) {
       throw std::runtime_error(std::string(srt_getlasterror_str()));
     }
   }
 
   if (rcvbuf >= 0) {
-    if (srt_setsockflag(srt_sock, SRTO_RCVBUF, &rcvbuf, sizeof rcvbuf) == SRT_ERROR) {
+    if (srt_setsockflag(srt_sock, SRTO_RCVBUF, &rcvbuf, sizeof rcvbuf) ==
+        SRT_ERROR) {
       throw std::runtime_error(std::string(srt_getlasterror_str()));
     }
   }
 
   if (udp_rcvbuf >= 0) {
-    if (srt_setsockflag(srt_sock, SRTO_UDP_RCVBUF, &udp_rcvbuf, sizeof udp_rcvbuf) == SRT_ERROR) {
+    if (srt_setsockflag(srt_sock, SRTO_UDP_RCVBUF, &udp_rcvbuf,
+                        sizeof udp_rcvbuf) == SRT_ERROR) {
       throw std::runtime_error(std::string(srt_getlasterror_str()));
     }
   }
 
   if (sndbuf >= 0) {
-    if (srt_setsockflag(srt_sock, SRTO_SNDBUF, &sndbuf, sizeof sndbuf) == SRT_ERROR) {
+    if (srt_setsockflag(srt_sock, SRTO_SNDBUF, &sndbuf, sizeof sndbuf) ==
+        SRT_ERROR) {
       throw std::runtime_error(std::string(srt_getlasterror_str()));
     }
   }
 
   if (udp_sndbuf >= 0) {
-    if (srt_setsockflag(srt_sock, SRTO_UDP_SNDBUF, &udp_sndbuf, sizeof udp_sndbuf) == SRT_ERROR) {
+    if (srt_setsockflag(srt_sock, SRTO_UDP_SNDBUF, &udp_sndbuf,
+                        sizeof udp_sndbuf) == SRT_ERROR) {
       throw std::runtime_error(std::string(srt_getlasterror_str()));
     }
   }
 
   if (sndtimeo >= 0) {
-    if (srt_setsockflag(srt_sock, SRTO_SNDTIMEO, &sndtimeo, sizeof sndtimeo) == SRT_ERROR) {
+    if (srt_setsockflag(srt_sock, SRTO_SNDTIMEO, &sndtimeo, sizeof sndtimeo) ==
+        SRT_ERROR) {
       throw std::runtime_error(std::string(srt_getlasterror_str()));
     }
   }
 
-  srt_bind_sock = srt_bind(srt_sock, reinterpret_cast<struct sockaddr*>(&ss), ss_len);
+  srt_bind_sock =
+      srt_bind(srt_sock, reinterpret_cast<struct sockaddr*>(&ss), ss_len);
   if (srt_bind_sock == SRT_ERROR) {
     throw std::runtime_error(std::string(srt_getlasterror_str()));
   }
@@ -113,45 +123,107 @@ void Server::Run(const std::string& address,
     throw std::runtime_error(std::string(srt_getlasterror_str()));
   }
 
+  sender_epoll = srt_epoll_create();
+  if (sender_epoll == SRT_ERROR) {
+    throw std::runtime_error(std::string(srt_getlasterror_str()));
+  }
+
   const int read_modes = SRT_EPOLL_IN | SRT_EPOLL_ERR;
   srt_epoll_add_usock(epoll, srt_sock, &read_modes);
 
   running.store(true);
+  telemetry_last_emit = std::chrono::steady_clock::now();
+  telemetry_last_drained_total = telemetry_drained_bytes_total.load();
 
   epoll_loop = std::thread(&Server::RunEpoll, this);
+  sender_loop = std::thread(&Server::RunSender, this);
 }
 
-std::unique_ptr<SrtSocketStats> Server::ReadSocketStats(int socket, bool clear_intervals) {
-  if (active_sockets.find(socket) != std::end(active_sockets)) {
-    return readSrtSocketStats(socket, clear_intervals);
+std::unique_ptr<SrtSocketStats> Server::ReadSocketStats(int socket,
+                                                        bool clear_intervals) {
+  {
+    std::lock_guard<std::mutex> lock(sockets_mutex);
+    if (active_sockets.find(socket) == std::end(active_sockets)) {
+      return nullptr;
+    }
   }
 
-  return nullptr;
+  return readSrtSocketStats(socket, clear_intervals);
 }
 
 void Server::Stop() {
-  if (running.load()) {
-    running.store(false);
-    epoll_loop.join();
+  if (running.exchange(false)) {
+    send_cv.notify_all();
+
+    if (epoll_loop.joinable()) {
+      epoll_loop.join();
+    }
+
+    if (sender_loop.joinable()) {
+      sender_loop.join();
+    }
   }
 
-  srt_epoll_release(epoll);
-  srt_close(srt_sock);
+  if (sender_epoll != -1) {
+    srt_epoll_release(sender_epoll);
+    sender_epoll = -1;
+  }
+
+  if (epoll != -1) {
+    srt_epoll_release(epoll);
+    epoll = -1;
+  }
+
+  if (srt_sock != -1) {
+    srt_close(srt_sock);
+    srt_sock = -1;
+  }
 }
 
-void Server::CloseConnection(int connection_id) {
-  if (auto connection = active_sockets.find(connection_id); connection != std::end(active_sockets)) {
-    srt_epoll_remove_usock(epoll, connection_id);
-    srt_close(connection_id);
+void Server::CloseConnection(int connection_id) { DisconnectSocket(connection_id); }
 
-    active_sockets.erase(connection_id);
-    this->on_socket_disconnected((SrtSocket)connection_id);
+Server::EnqueueResult Server::EnqueueData(SrtSocket connection_id,
+                                          std::unique_ptr<char[]> data,
+                                          int len) {
+  if (len <= 0 || !data) {
+    return EnqueueResult::InvalidPayload;
   }
+
+  if (!running.load()) {
+    return EnqueueResult::SocketClosed;
+  }
+
+  std::lock_guard<std::mutex> lock(send_mutex);
+  auto it = send_queues.find(connection_id);
+  if (it == send_queues.end()) {
+    return EnqueueResult::SocketNotFound;
+  }
+
+  auto& q = it->second;
+  if (q.queue.size() >= max_pending_messages_per_conn ||
+      q.queued_bytes + static_cast<uint64_t>(len) >
+          max_pending_bytes_per_conn) {
+    telemetry_enqueue_drops.fetch_add(1);
+    return EnqueueResult::WouldBlock;
+  }
+
+  q.queue.push_back(PendingMessage{std::move(data), len});
+  q.queued_bytes += static_cast<uint64_t>(len);
+  telemetry_queue_depth_bytes.fetch_add(static_cast<uint64_t>(len));
+
+  if (!q.out_enabled) {
+    const int write_modes = SRT_EPOLL_OUT | SRT_EPOLL_ERR;
+    if (srt_epoll_update_usock(sender_epoll, connection_id, &write_modes) !=
+        SRT_ERROR) {
+      q.out_enabled = true;
+    }
+  }
+
+  send_cv.notify_one();
+  return EnqueueResult::Ok;
 }
 
 void Server::RunEpoll() {
-  // Setting this one prevents spamming with "no sockets to check, this would deadlock" logs during closing
-  // of the system, when there are no sockets in the epoll anymore
   srt_epoll_set(epoll, SRT_EPOLL_ENABLE_EMPTY);
 
   int sockets_len = 100;
@@ -164,21 +236,12 @@ void Server::RunEpoll() {
     sockets_len = 100;
     broken_sockets_len = 100;
 
-    int n = srt_epoll_wait(epoll,
-                           sockets.data(),
-                           &sockets_len,
-                           broken_sockets.data(),
-                           &broken_sockets_len,
-                           1000,
-                           0,
-                           0,
-                           0,
-                           0);
+    int n = srt_epoll_wait(epoll, sockets.data(), &sockets_len,
+                           broken_sockets.data(), &broken_sockets_len, 1000, 0,
+                           0, 0, 0);
 
     if (n < 1) {
-      // clear out the time out error
       srt_clearlasterror();
-
       continue;
     }
 
@@ -191,8 +254,6 @@ void Server::RunEpoll() {
         DisconnectSocket(sockets[i]);
       } else if (socket_state == SRTS_CONNECTED) {
         ReadSocketData(sockets[i]);
-      } else {
-        printf("[WARNING] Encountered new socket state, report it to maintainers -> %d\n", socket_state);
       }
     }
 
@@ -209,6 +270,111 @@ void Server::RunEpoll() {
         DisconnectSocket(broken_sockets[i]);
       }
     }
+  }
+}
+
+void Server::RunSender() {
+  srt_epoll_set(sender_epoll, SRT_EPOLL_ENABLE_EMPTY);
+
+  while (running.load()) {
+    int read_len = 128;
+    int write_len = 128;
+    SrtSocket read_sockets[128];
+    SrtSocket write_sockets[128];
+
+    int n = srt_epoll_wait(sender_epoll, read_sockets, &read_len, write_sockets,
+                           &write_len, 200, 0, 0, 0, 0);
+
+    if (n < 0) {
+      srt_clearlasterror();
+      MaybeEmitSendTelemetry();
+      continue;
+    }
+
+    for (int i = 0; i < read_len; ++i) {
+      auto state = srt_getsockstate(read_sockets[i]);
+      if (state == SRTS_CLOSED || state == SRTS_BROKEN) {
+        DisconnectSocket(read_sockets[i]);
+      }
+    }
+
+    for (int i = 0; i < write_len; ++i) {
+      DrainSendQueue(write_sockets[i]);
+    }
+
+    MaybeEmitSendTelemetry();
+  }
+
+  MaybeEmitSendTelemetry(true);
+}
+
+void Server::DrainSendQueue(SrtSocket socket) {
+  while (running.load()) {
+    PendingMessage msg;
+
+    {
+      std::lock_guard<std::mutex> lock(send_mutex);
+      auto qit = send_queues.find(socket);
+      if (qit == send_queues.end()) {
+        return;
+      }
+
+      auto& q = qit->second;
+      if (q.queue.empty()) {
+        if (q.out_enabled) {
+          const int err_modes = SRT_EPOLL_ERR;
+          if (srt_epoll_update_usock(sender_epoll, socket, &err_modes) !=
+              SRT_ERROR) {
+            q.out_enabled = false;
+          }
+        }
+        return;
+      }
+
+      msg = std::move(q.queue.front());
+      q.queue.pop_front();
+      q.queued_bytes -= static_cast<uint64_t>(msg.len);
+      telemetry_queue_depth_bytes.fetch_sub(static_cast<uint64_t>(msg.len));
+    }
+
+    int sent = srt_sendmsg(socket, msg.data.get(), msg.len, -1, 0);
+    if (sent == SRT_ERROR) {
+      int err = srt_getlasterror(nullptr);
+
+      if (err == SRT_EASYNCSND || err == SRT_ETIMEOUT) {
+        telemetry_send_retries.fetch_add(1);
+
+        std::lock_guard<std::mutex> lock(send_mutex);
+        auto qit = send_queues.find(socket);
+        if (qit != send_queues.end()) {
+          auto& q = qit->second;
+          q.queue.push_front(std::move(msg));
+          q.queued_bytes += static_cast<uint64_t>(q.queue.front().len);
+          telemetry_queue_depth_bytes.fetch_add(
+              static_cast<uint64_t>(q.queue.front().len));
+          if (!q.out_enabled) {
+            const int write_modes = SRT_EPOLL_OUT | SRT_EPOLL_ERR;
+            if (srt_epoll_update_usock(sender_epoll, socket, &write_modes) !=
+                SRT_ERROR) {
+              q.out_enabled = true;
+            }
+          }
+        }
+
+        return;
+      }
+
+      auto state = srt_getsockstate(socket);
+      if (state == SRTS_CLOSED || state == SRTS_BROKEN) {
+        DisconnectSocket(socket);
+        return;
+      }
+
+      telemetry_enqueue_drops.fetch_add(1);
+      continue;
+    }
+
+    telemetry_drained_bytes_total.fetch_add(static_cast<uint64_t>(sent));
   }
 }
 
@@ -246,7 +412,6 @@ int Server::OnNewConnection(SRTSOCKET ns,
   int no = 0;
   srt_setsockflag(ns, SRTO_SNDSYN, &no, sizeof no);
 
-  // Set password if provided
   if (!password.empty()) {
     srt_setsockflag(ns, SRTO_PASSPHRASE, password.c_str(), password.length());
   }
@@ -263,7 +428,6 @@ int Server::OnNewConnection(SRTSOCKET ns,
 
   this->on_connect_request(address, streamid);
 
-  // NOTE: this check should be very fast as it blocks any receiving on the socket
   auto result = accept_cv.wait_for(lock, std::chrono::milliseconds(1000));
 
   if (result == std::cv_status::timeout) {
@@ -303,21 +467,47 @@ bool Server::IsSocketClosed(Server::SrtSocket socket) const {
 }
 
 void Server::DisconnectSocket(Server::SrtSocket socket) {
-  srt_epoll_remove_usock(epoll, socket);
-  srt_close(socket);
+  bool should_notify = false;
 
-  active_sockets.erase(socket);
-  this->on_socket_disconnected(socket);
+  {
+    std::lock_guard<std::mutex> lock(sockets_mutex);
+    if (active_sockets.erase(socket) > 0) {
+      should_notify = true;
+    }
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(send_mutex);
+    auto qit = send_queues.find(socket);
+    if (qit != send_queues.end()) {
+      telemetry_queue_depth_bytes.fetch_sub(qit->second.queued_bytes);
+      send_queues.erase(qit);
+    }
+  }
+
+  if (epoll != -1) {
+    srt_epoll_remove_usock(epoll, socket);
+  }
+
+  if (sender_epoll != -1) {
+    srt_epoll_remove_usock(sender_epoll, socket);
+  }
+
+  if (socket != -1) {
+    srt_close(socket);
+  }
+
+  if (should_notify) {
+    this->on_socket_disconnected(socket);
+  }
 }
 
 void Server::ReadSocketData(Server::SrtSocket socket) {
-  static constexpr int max_read_per_cycle = 20;
   char batch_buf[max_read_per_cycle * 1500];
-  int  batch_len = 0;
+  int batch_len = 0;
 
   for (int i = 0; i < max_read_per_cycle; ++i) {
-    int n = srt_recv(socket, batch_buf + batch_len,
-                     sizeof(batch_buf) - batch_len);
+    int n = srt_recv(socket, batch_buf + batch_len, sizeof(batch_buf) - batch_len);
 
     if (n == SRT_ERROR) {
       if (srt_getlasterror(nullptr) == SRT_EASYNCRCV) {
@@ -352,7 +542,7 @@ void Server::AcceptConnection() {
 
   int socket = srt_accept(srt_sock, (struct sockaddr*)&their_addr, &addr_len);
   if (socket == -1) {
-    throw new std::runtime_error("Failed to accept new socket");
+    throw std::runtime_error("Failed to accept new socket");
   }
 
   char raw_streamid[512] = {0};
@@ -361,9 +551,55 @@ void Server::AcceptConnection() {
 
   auto streamid = std::string(raw_streamid, raw_streamid + max_streamid_len);
 
-  this->on_socket_connected(socket, streamid);
-  active_sockets.insert(socket);
+  {
+    std::lock_guard<std::mutex> lock(sockets_mutex);
+    active_sockets.insert(socket);
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(send_mutex);
+    send_queues.emplace(socket, ConnectionQueue{});
+  }
 
   const int read_modes = SRT_EPOLL_IN | SRT_EPOLL_ERR;
   srt_epoll_add_usock(epoll, socket, &read_modes);
+
+  const int sender_modes = SRT_EPOLL_ERR;
+  srt_epoll_add_usock(sender_epoll, socket, &sender_modes);
+
+  this->on_socket_connected(socket, streamid);
+}
+
+void Server::MaybeEmitSendTelemetry(bool force) {
+  if (!on_send_telemetry) {
+    return;
+  }
+
+  auto now = std::chrono::steady_clock::now();
+  if (!force && now - telemetry_last_emit < std::chrono::seconds(1)) {
+    return;
+  }
+
+  auto drained_total = telemetry_drained_bytes_total.load();
+  auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                        now - telemetry_last_emit)
+                        .count();
+  if (elapsed_ms <= 0) {
+    elapsed_ms = 1;
+  }
+
+  uint64_t drained_delta = drained_total - telemetry_last_drained_total;
+  uint64_t drain_rate_bps = drained_delta * 8ULL * 1000ULL /
+                            static_cast<uint64_t>(elapsed_ms);
+
+  SendTelemetry telemetry;
+  telemetry.queue_depth_bytes = telemetry_queue_depth_bytes.load();
+  telemetry.enqueue_drops = telemetry_enqueue_drops.load();
+  telemetry.send_retries = telemetry_send_retries.load();
+  telemetry.drain_rate_bps = drain_rate_bps;
+
+  telemetry_last_drained_total = drained_total;
+  telemetry_last_emit = now;
+
+  on_send_telemetry(telemetry);
 }

--- a/c_src/ex_libsrt/server/server.cpp
+++ b/c_src/ex_libsrt/server/server.cpp
@@ -14,9 +14,11 @@ void Server::Run(const std::string& address,
                  int rcvbuf,
                  int udp_rcvbuf,
                  int sndbuf,
-                 int udp_sndbuf) {
+                 int udp_sndbuf,
+                 int sndtimeo) {
   this->password = password;
   this->latency_ms = latency_ms;
+  this->sndtimeo = sndtimeo;
 
   struct sockaddr_storage ss;
   socklen_t ss_len;
@@ -55,6 +57,7 @@ void Server::Run(const std::string& address,
   }
 
   srt_setsockflag(srt_sock, SRTO_RCVSYN, &no, sizeof yes);
+  srt_setsockflag(srt_sock, SRTO_SNDSYN, &no, sizeof yes);
   srt_setsockflag(srt_sock, SRTO_STREAMID, &yes, sizeof yes);
   if (latency_ms >= 0) {
     if (srt_setsockflag(srt_sock, SRTO_LATENCY, &latency_ms, sizeof latency_ms) == SRT_ERROR) {
@@ -82,6 +85,12 @@ void Server::Run(const std::string& address,
 
   if (udp_sndbuf >= 0) {
     if (srt_setsockflag(srt_sock, SRTO_UDP_SNDBUF, &udp_sndbuf, sizeof udp_sndbuf) == SRT_ERROR) {
+      throw std::runtime_error(std::string(srt_getlasterror_str()));
+    }
+  }
+
+  if (sndtimeo >= 0) {
+    if (srt_setsockflag(srt_sock, SRTO_SNDTIMEO, &sndtimeo, sizeof sndtimeo) == SRT_ERROR) {
       throw std::runtime_error(std::string(srt_getlasterror_str()));
     }
   }
@@ -234,12 +243,18 @@ int Server::OnNewConnection(SRTSOCKET ns,
     address = ip;
   }
 
+  int no = 0;
+  srt_setsockflag(ns, SRTO_SNDSYN, &no, sizeof no);
+
   // Set password if provided
   if (!password.empty()) {
     srt_setsockflag(ns, SRTO_PASSPHRASE, password.c_str(), password.length());
   }
   if (latency_ms >= 0) {
     srt_setsockflag(ns, SRTO_LATENCY, &latency_ms, sizeof latency_ms);
+  }
+  if (sndtimeo >= 0) {
+    srt_setsockflag(ns, SRTO_SNDTIMEO, &sndtimeo, sizeof sndtimeo);
   }
 
   std::unique_lock<std::mutex> lock(accept_mutex);

--- a/c_src/ex_libsrt/server/server.cpp
+++ b/c_src/ex_libsrt/server/server.cpp
@@ -296,14 +296,36 @@ void Server::DisconnectSocket(Server::SrtSocket socket) {
 }
 
 void Server::ReadSocketData(Server::SrtSocket socket) {
-  char buffer[1500];
+  static constexpr int max_read_per_cycle = 20;
+  bool got_any = false;
 
-  int n = srt_recv(socket, buffer, sizeof(buffer));
+  for (int i = 0; i < max_read_per_cycle; ++i) {
+    char buffer[1500];
+    int n = srt_recv(socket, buffer, sizeof(buffer));
 
-  if (n == 0 || n == SRT_ERROR) {
-    DisconnectSocket(socket);
-  } else {
+    if (n == SRT_ERROR) {
+      if (srt_getlasterror(nullptr) == SRT_EASYNCRCV) {
+        break;
+      }
+
+      if (!got_any) {
+        DisconnectSocket(socket);
+        return;
+      }
+
+      break;
+    }
+
+    if (n == 0) {
+      break;
+    }
+
+    got_any = true;
     this->on_socket_data(socket, buffer, n);
+  }
+
+  if (!got_any) {
+    DisconnectSocket(socket);
   }
 }
 

--- a/c_src/ex_libsrt/server/server.cpp
+++ b/c_src/ex_libsrt/server/server.cpp
@@ -297,18 +297,19 @@ void Server::DisconnectSocket(Server::SrtSocket socket) {
 
 void Server::ReadSocketData(Server::SrtSocket socket) {
   static constexpr int max_read_per_cycle = 20;
-  bool got_any = false;
+  char batch_buf[max_read_per_cycle * 1500];
+  int  batch_len = 0;
 
   for (int i = 0; i < max_read_per_cycle; ++i) {
-    char buffer[1500];
-    int n = srt_recv(socket, buffer, sizeof(buffer));
+    int n = srt_recv(socket, batch_buf + batch_len,
+                     sizeof(batch_buf) - batch_len);
 
     if (n == SRT_ERROR) {
       if (srt_getlasterror(nullptr) == SRT_EASYNCRCV) {
         break;
       }
 
-      if (!got_any) {
+      if (batch_len == 0) {
         DisconnectSocket(socket);
         return;
       }
@@ -320,12 +321,13 @@ void Server::ReadSocketData(Server::SrtSocket socket) {
       break;
     }
 
-    got_any = true;
-    this->on_socket_data(socket, buffer, n);
+    batch_len += n;
   }
 
-  if (!got_any) {
+  if (batch_len == 0) {
     DisconnectSocket(socket);
+  } else {
+    this->on_socket_data(socket, batch_buf, batch_len);
   }
 }
 

--- a/c_src/ex_libsrt/server/server.cpp
+++ b/c_src/ex_libsrt/server/server.cpp
@@ -189,6 +189,20 @@ Server::EnqueueResult Server::EnqueueData(SrtSocket connection_id,
     return EnqueueResult::InvalidPayload;
   }
 
+  std::vector<PendingMessage> messages;
+  messages.push_back(PendingMessage{std::move(data), len});
+  return EnqueueBatchData(connection_id, std::move(messages),
+                          static_cast<uint64_t>(len));
+}
+
+Server::EnqueueResult Server::EnqueueBatchData(
+    SrtSocket connection_id,
+    std::vector<PendingMessage>&& messages,
+    uint64_t total_bytes) {
+  if (messages.empty() || total_bytes == 0) {
+    return EnqueueResult::InvalidPayload;
+  }
+
   if (!running.load()) {
     return EnqueueResult::SocketClosed;
   }
@@ -200,16 +214,18 @@ Server::EnqueueResult Server::EnqueueData(SrtSocket connection_id,
   }
 
   auto& q = it->second;
-  if (q.queue.size() >= max_pending_messages_per_conn ||
-      q.queued_bytes + static_cast<uint64_t>(len) >
-          max_pending_bytes_per_conn) {
+  if (q.queue.size() + messages.size() > max_pending_messages_per_conn ||
+      q.queued_bytes + total_bytes > max_pending_bytes_per_conn) {
     telemetry_enqueue_drops.fetch_add(1);
     return EnqueueResult::WouldBlock;
   }
 
-  q.queue.push_back(PendingMessage{std::move(data), len});
-  q.queued_bytes += static_cast<uint64_t>(len);
-  telemetry_queue_depth_bytes.fetch_add(static_cast<uint64_t>(len));
+  for (auto& msg : messages) {
+    q.queue.push_back(std::move(msg));
+  }
+
+  q.queued_bytes += total_bytes;
+  telemetry_queue_depth_bytes.fetch_add(total_bytes);
 
   if (!q.out_enabled) {
     const int write_modes = SRT_EPOLL_OUT | SRT_EPOLL_ERR;

--- a/c_src/ex_libsrt/server/server.h
+++ b/c_src/ex_libsrt/server/server.h
@@ -33,7 +33,8 @@ public:
            int rcvbuf = -1,
            int udp_rcvbuf = -1,
            int sndbuf = -1,
-           int udp_sndbuf = -1);
+           int udp_sndbuf = -1,
+           int sndtimeo = -1);
 
   void Stop();
 
@@ -99,6 +100,7 @@ private:
   SrtSocket srt_bind_sock;
   std::string password;
   int latency_ms = -1;
+  int sndtimeo = -1;
 
   std::atomic_bool running;
   SrtEpoll epoll;

--- a/c_src/ex_libsrt/server/server.h
+++ b/c_src/ex_libsrt/server/server.h
@@ -2,14 +2,18 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <cstdint>
+#include <deque>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <set>
 #include <srt/srt.h>
 #include <string>
 #include <thread>
-#include <set>
+#include <unordered_map>
+
 #include "../common/srt_socket_stats.h"
 
 extern "C" {
@@ -19,9 +23,24 @@ extern "C" {
 class Server {
   static const int MAX_PENDING_CONNECTIONS = 5;
 
-public:
+ public:
   using SrtSocket = int;
   using SrtEpoll = int;
+
+  struct SendTelemetry {
+    uint64_t queue_depth_bytes = 0;
+    uint64_t enqueue_drops = 0;
+    uint64_t send_retries = 0;
+    uint64_t drain_rate_bps = 0;
+  };
+
+  enum class EnqueueResult {
+    Ok,
+    WouldBlock,
+    SocketNotFound,
+    SocketClosed,
+    InvalidPayload,
+  };
 
   Server() = default;
   ~Server() = default;
@@ -42,9 +61,16 @@ public:
 
   void AnswerConnectRequest(int accept);
 
-  SrtSocket GetAwaitingConnectionRequestId() const { return awaiting_connect_request_socket; }
+  SrtSocket GetAwaitingConnectionRequestId() const {
+    return awaiting_connect_request_socket;
+  }
 
-  std::unique_ptr<SrtSocketStats> ReadSocketStats(int socket, bool clear_intervals);
+  std::unique_ptr<SrtSocketStats> ReadSocketStats(int socket,
+                                                  bool clear_intervals);
+
+  EnqueueResult EnqueueData(SrtSocket connection_id,
+                            std::unique_ptr<char[]> data,
+                            int len);
 
   void SetOnSocketConnected(
       std::function<void(SrtSocket, const std::string&)> on_socket_connected) {
@@ -61,8 +87,7 @@ public:
     this->on_socket_data = std::move(on_socket_data);
   }
 
-  void
-  SetOnFatalError(std::function<void(const std::string&)>&& on_fatal_error) {
+  void SetOnFatalError(std::function<void(const std::string&)>&& on_fatal_error) {
     this->on_fatal_error = std::move(on_fatal_error);
   }
 
@@ -72,7 +97,23 @@ public:
     this->on_connect_request = std::move(on_connect_request);
   }
 
-private:
+  void SetOnSendTelemetry(
+      std::function<void(const SendTelemetry&)>&& on_send_telemetry) {
+    this->on_send_telemetry = std::move(on_send_telemetry);
+  }
+
+ private:
+  struct PendingMessage {
+    std::unique_ptr<char[]> data;
+    int len;
+  };
+
+  struct ConnectionQueue {
+    std::deque<PendingMessage> queue;
+    uint64_t queued_bytes = 0;
+    bool out_enabled = false;
+  };
+
   bool IsListeningSocket(SrtSocket socket) const;
   bool IsSocketBroken(SrtSocket socket) const;
   bool IsSocketClosed(SrtSocket socket) const;
@@ -83,6 +124,9 @@ private:
   void AcceptConnection();
 
   void RunEpoll();
+  void RunSender();
+  void DrainSendQueue(SrtSocket socket);
+  void MaybeEmitSendTelemetry(bool force = false);
 
   static int ListenAcceptCallback(void* opaque,
                                   SRTSOCKET ns,
@@ -95,25 +139,43 @@ private:
                       const struct sockaddr* peeraddr,
                       const char* streamid);
 
-private:
-  SrtSocket srt_sock;
-  SrtSocket srt_bind_sock;
+ private:
+  static constexpr int max_read_per_cycle = 20;
+  static constexpr size_t max_pending_messages_per_conn = 4096;
+  static constexpr uint64_t max_pending_bytes_per_conn = 64 * 1024 * 1024;
+
+  SrtSocket srt_sock = -1;
+  SrtSocket srt_bind_sock = -1;
   std::string password;
   int latency_ms = -1;
   int sndtimeo = -1;
 
-  std::atomic_bool running;
-  SrtEpoll epoll;
+  std::atomic_bool running{false};
+  SrtEpoll epoll = -1;
+  SrtEpoll sender_epoll = -1;
   std::thread epoll_loop;
+  std::thread sender_loop;
 
-private:
+  std::mutex sockets_mutex;
   std::set<SrtSocket> active_sockets;
+
+  std::mutex send_mutex;
+  std::condition_variable send_cv;
+  std::unordered_map<SrtSocket, ConnectionQueue> send_queues;
+
+  std::atomic<uint64_t> telemetry_queue_depth_bytes{0};
+  std::atomic<uint64_t> telemetry_enqueue_drops{0};
+  std::atomic<uint64_t> telemetry_send_retries{0};
+  std::atomic<uint64_t> telemetry_drained_bytes_total{0};
+  uint64_t telemetry_last_drained_total = 0;
+  std::chrono::steady_clock::time_point telemetry_last_emit;
+
   std::function<void(SrtSocket, const std::string&)> on_socket_connected;
   std::function<void(SrtSocket)> on_socket_disconnected;
   std::function<void(SrtSocket, const char*, int)> on_socket_data;
   std::function<void(const std::string&)> on_fatal_error;
-  std::function<void(const std::string&, const std::string&)>
-      on_connect_request;
+  std::function<void(const std::string&, const std::string&)> on_connect_request;
+  std::function<void(const SendTelemetry&)> on_send_telemetry;
 
   std::mutex accept_mutex;
   std::condition_variable accept_cv;

--- a/c_src/ex_libsrt/server/server.h
+++ b/c_src/ex_libsrt/server/server.h
@@ -29,7 +29,11 @@ public:
   void Run(const std::string& address,
            int port,
            const std::string& password = "",
-           int latency_ms = -1);
+           int latency_ms = -1,
+           int rcvbuf = -1,
+           int udp_rcvbuf = -1,
+           int sndbuf = -1,
+           int udp_sndbuf = -1);
 
   void Stop();
 

--- a/c_src/ex_libsrt/server/server.h
+++ b/c_src/ex_libsrt/server/server.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include <vector>
 
 #include "../common/srt_socket_stats.h"
 
@@ -32,6 +33,11 @@ class Server {
     uint64_t enqueue_drops = 0;
     uint64_t send_retries = 0;
     uint64_t drain_rate_bps = 0;
+  };
+
+  struct PendingMessage {
+    std::unique_ptr<char[]> data;
+    int len;
   };
 
   enum class EnqueueResult {
@@ -72,6 +78,10 @@ class Server {
                             std::unique_ptr<char[]> data,
                             int len);
 
+  EnqueueResult EnqueueBatchData(SrtSocket connection_id,
+                                 std::vector<PendingMessage>&& messages,
+                                 uint64_t total_bytes);
+
   void SetOnSocketConnected(
       std::function<void(SrtSocket, const std::string&)> on_socket_connected) {
     this->on_socket_connected = std::move(on_socket_connected);
@@ -103,11 +113,6 @@ class Server {
   }
 
  private:
-  struct PendingMessage {
-    std::unique_ptr<char[]> data;
-    int len;
-  };
-
   struct ConnectionQueue {
     std::deque<PendingMessage> queue;
     uint64_t queued_bytes = 0;

--- a/c_src/ex_libsrt/srt_nif.cpp
+++ b/c_src/ex_libsrt/srt_nif.cpp
@@ -319,13 +319,26 @@ start_client(UnifexEnv* env,
       throw new std::runtime_error("failed to create native state");
     };
 
-    state->client = std::make_unique<Client>(10, 200);
+    state->client = std::make_unique<Client>(10, 200, true);
 
     state->client->SetOnSocketConnected(
         [=]() { send_srt_client_connected(state->env, state->owner, 1); });
 
     state->client->SetOnSocketDisconnected(
         [=]() { send_srt_client_disconnected(state->env, state->owner, 1); });
+
+    state->client->SetOnSocketData([=](const char* data, int len) {
+      UnifexPayload* payload =
+          (UnifexPayload*)unifex_alloc(sizeof(UnifexPayload));
+
+      unifex_payload_alloc(state->env, UNIFEX_PAYLOAD_BINARY, len, payload);
+      memcpy(payload->data, data, len);
+
+      send_srt_data(state->env, state->owner, 1, 0, payload);
+
+      unifex_payload_release(payload);
+      unifex_free(payload);
+    });
 
     state->client->SetOnSocketError([=](const std::string& reason) {
       send_srt_client_error(state->env, state->owner, 1, reason.c_str());
@@ -354,6 +367,69 @@ start_client(UnifexEnv* env,
   }
 }
 
+UNIFEX_TERM start_client_with_mode(UnifexEnv* env,
+                                   char* server_address,
+                                   int port,
+                                   char* stream_id,
+                                   char* password,
+                                   int latency_ms,
+                                   int sender_mode) {
+  State* state = unifex_alloc_state(env);
+  state = new (state) State();
+
+  try {
+    state->env = unifex_alloc_env(env);
+    if (!unifex_self(env, &state->owner)) {
+      throw new std::runtime_error("failed to create native state");
+    };
+
+    state->client = std::make_unique<Client>(10, 200, sender_mode != 0);
+
+    state->client->SetOnSocketConnected(
+        [=]() { send_srt_client_connected(state->env, state->owner, 1); });
+
+    state->client->SetOnSocketDisconnected(
+        [=]() { send_srt_client_disconnected(state->env, state->owner, 1); });
+
+    state->client->SetOnSocketData([=](const char* data, int len) {
+      UnifexPayload* payload =
+          (UnifexPayload*)unifex_alloc(sizeof(UnifexPayload));
+
+      unifex_payload_alloc(state->env, UNIFEX_PAYLOAD_BINARY, len, payload);
+      memcpy(payload->data, data, len);
+
+      send_srt_data(state->env, state->owner, 1, 0, payload);
+
+      unifex_payload_release(payload);
+      unifex_free(payload);
+    });
+
+    state->client->SetOnSocketError([=](const std::string& reason) {
+      send_srt_client_error(state->env, state->owner, 1, reason.c_str());
+    });
+
+    state->client->Run(std::string(server_address),
+                       port,
+                       std::string(stream_id),
+                       std::string(password),
+                       latency_ms);
+
+    UNIFEX_TERM result = start_client_with_mode_result_ok(env, state);
+    unifex_release_state(env, state);
+
+    return result;
+  } catch (const Client::StreamRejectedException& e) {
+    auto code = e.GetCode();
+
+    unifex_release_state(env, state);
+
+    return start_client_with_mode_result_error(env, e.what(), code);
+  } catch (const std::exception& e) {
+    unifex_release_state(env, state);
+
+    return start_client_with_mode_result_error(env, e.what(), -1);
+  }
+}
 
 UNIFEX_TERM
 send_client_data(UnifexEnv* env, UnifexPayload* payload, UnifexState* state) {

--- a/c_src/ex_libsrt/srt_nif.cpp
+++ b/c_src/ex_libsrt/srt_nif.cpp
@@ -133,7 +133,8 @@ UNIFEX_TERM start_server(UnifexEnv* env,
                          int rcvbuf,
                          int udp_rcvbuf,
                          int sndbuf,
-                         int udp_sndbuf) {
+                         int udp_sndbuf,
+                         int sndtimeo) {
   State* state = unifex_alloc_state(env);
   state = new (state) State();
 
@@ -194,7 +195,7 @@ UNIFEX_TERM start_server(UnifexEnv* env,
               state->env, state->owner, 1, address.c_str(), stream_id.c_str());
         });
 
-    state->server->Run(std::string(address), port, std::string(password), latency_ms, rcvbuf, udp_rcvbuf, sndbuf, udp_sndbuf);
+    state->server->Run(std::string(address), port, std::string(password), latency_ms, rcvbuf, udp_rcvbuf, sndbuf, udp_sndbuf, sndtimeo);
 
     UNIFEX_TERM result = start_server_result_ok(env, state);
     unifex_release_state(env, state);

--- a/c_src/ex_libsrt/srt_nif.cpp
+++ b/c_src/ex_libsrt/srt_nif.cpp
@@ -129,7 +129,11 @@ UNIFEX_TERM start_server(UnifexEnv* env,
                          char* address,
                          int port,
                          char* password,
-                         int latency_ms) {
+                         int latency_ms,
+                         int rcvbuf,
+                         int udp_rcvbuf,
+                         int sndbuf,
+                         int udp_sndbuf) {
   State* state = unifex_alloc_state(env);
   state = new (state) State();
 
@@ -190,7 +194,7 @@ UNIFEX_TERM start_server(UnifexEnv* env,
               state->env, state->owner, 1, address.c_str(), stream_id.c_str());
         });
 
-    state->server->Run(std::string(address), port, std::string(password), latency_ms);
+    state->server->Run(std::string(address), port, std::string(password), latency_ms, rcvbuf, udp_rcvbuf, sndbuf, udp_sndbuf);
 
     UNIFEX_TERM result = start_server_result_ok(env, state);
     unifex_release_state(env, state);
@@ -309,7 +313,11 @@ UNIFEX_TERM start_client_native(UnifexEnv* env,
                                   char* stream_id,
                                   char* password,
                                   int latency_ms,
-                                  int sender_mode) {
+                                  int sender_mode,
+                                  int rcvbuf,
+                                  int udp_rcvbuf,
+                                  int sndbuf,
+                                  int udp_sndbuf) {
   State* state = unifex_alloc_state(env);
   state = new (state) State();
 
@@ -348,7 +356,11 @@ UNIFEX_TERM start_client_native(UnifexEnv* env,
                        port,
                        std::string(stream_id),
                        std::string(password),
-                       latency_ms);
+                       latency_ms,
+                       rcvbuf,
+                       udp_rcvbuf,
+                       sndbuf,
+                       udp_sndbuf);
 
     UNIFEX_TERM result = start_client_native_result_ok(env, state);
     unifex_release_state(env, state);

--- a/c_src/ex_libsrt/srt_nif.cpp
+++ b/c_src/ex_libsrt/srt_nif.cpp
@@ -1,4 +1,5 @@
 #include "srt_nif.h"
+#include <cstdint>
 #include <cstdlib>
 #include <thread>
 #include <vector>
@@ -195,6 +196,16 @@ UNIFEX_TERM start_server(UnifexEnv* env,
               state->env, state->owner, 1, address.c_str(), stream_id.c_str());
         });
 
+    state->server->SetOnSendTelemetry([=](const Server::SendTelemetry& telemetry) {
+      send_srt_server_send_telemetry(state->env,
+                                     state->owner,
+                                     1,
+                                     telemetry.queue_depth_bytes,
+                                     telemetry.enqueue_drops,
+                                     telemetry.send_retries,
+                                     telemetry.drain_rate_bps);
+    });
+
     state->server->Run(std::string(address), port, std::string(password), latency_ms, rcvbuf, udp_rcvbuf, sndbuf, udp_sndbuf, sndtimeo);
 
     UNIFEX_TERM result = start_server_result_ok(env, state);
@@ -284,28 +295,71 @@ send_server_data(UnifexEnv* env,
     return send_server_data_result_error(env, "Server is not active");
   }
 
-  {
-    std::shared_lock lock(state->conn_receivers_mutex);
+  auto buffer = std::unique_ptr<char[]>(new char[payload->size]);
+  memcpy(buffer.get(), payload->data, payload->size);
 
-    if (state->conn_receivers.find(conn_id) == std::end(state->conn_receivers)) {
+  auto result = state->server->EnqueueData(conn_id, std::move(buffer), payload->size);
+  switch (result) {
+    case Server::EnqueueResult::Ok:
+      return send_server_data_result_ok(env);
+    case Server::EnqueueResult::WouldBlock:
+      return send_server_data_result_error(env, "would_block");
+    case Server::EnqueueResult::SocketNotFound:
       return send_server_data_result_error(env, "Socket not found");
-    }
-  }
-
-  auto result =
-      srt_sendmsg(conn_id, reinterpret_cast<const char*>(payload->data), payload->size, -1, 0);
-
-  if (result == SRT_ERROR) {
-    auto socket_state = srt_getsockstate(conn_id);
-
-    if (socket_state == SRTS_CLOSED || socket_state == SRTS_BROKEN) {
+    case Server::EnqueueResult::SocketClosed:
       return send_server_data_result_error(env, "Socket is closed or broken");
-    }
+    case Server::EnqueueResult::InvalidPayload:
+    default:
+      return send_server_data_result_error(env, "Invalid payload");
+  }
+}
 
-    return send_server_data_result_error(env, srt_getlasterror_str());
+UNIFEX_TERM
+send_server_data_many(UnifexEnv* env,
+                      int conn_id,
+                      UnifexPayload* payload,
+                      UnifexState* state) {
+  if (state->server == nullptr) {
+    return send_server_data_many_result_error(env, "Server is not active");
   }
 
-  return send_server_data_result_ok(env);
+  size_t offset = 0;
+  while (offset + 2 <= payload->size) {
+    uint16_t len = (static_cast<uint16_t>(payload->data[offset]) << 8) |
+                   static_cast<uint16_t>(payload->data[offset + 1]);
+    offset += 2;
+
+    if (len == 0 || offset + len > payload->size) {
+      return send_server_data_many_result_error(env, "Invalid batch payload");
+    }
+
+    auto buffer = std::unique_ptr<char[]>(new char[len]);
+    memcpy(buffer.get(), payload->data + offset, len);
+    offset += len;
+
+    auto result = state->server->EnqueueData(conn_id, std::move(buffer), len);
+    if (result == Server::EnqueueResult::Ok) {
+      continue;
+    }
+
+    switch (result) {
+      case Server::EnqueueResult::WouldBlock:
+        return send_server_data_many_result_error(env, "would_block");
+      case Server::EnqueueResult::SocketNotFound:
+        return send_server_data_many_result_error(env, "Socket not found");
+      case Server::EnqueueResult::SocketClosed:
+        return send_server_data_many_result_error(env, "Socket is closed or broken");
+      case Server::EnqueueResult::InvalidPayload:
+      default:
+        return send_server_data_many_result_error(env, "Invalid payload");
+    }
+  }
+
+  if (offset != payload->size) {
+    return send_server_data_many_result_error(env, "Invalid batch payload");
+  }
+
+  return send_server_data_many_result_ok(env);
 }
 
 UNIFEX_TERM start_client_native(UnifexEnv* env,

--- a/c_src/ex_libsrt/srt_nif.cpp
+++ b/c_src/ex_libsrt/srt_nif.cpp
@@ -323,6 +323,10 @@ send_server_data_many(UnifexEnv* env,
     return send_server_data_many_result_error(env, "Server is not active");
   }
 
+  std::vector<Server::PendingMessage> messages;
+  messages.reserve(16);
+
+  uint64_t total_bytes = 0;
   size_t offset = 0;
   while (offset + 2 <= payload->size) {
     uint16_t len = (static_cast<uint16_t>(payload->data[offset]) << 8) |
@@ -337,29 +341,28 @@ send_server_data_many(UnifexEnv* env,
     memcpy(buffer.get(), payload->data + offset, len);
     offset += len;
 
-    auto result = state->server->EnqueueData(conn_id, std::move(buffer), len);
-    if (result == Server::EnqueueResult::Ok) {
-      continue;
-    }
-
-    switch (result) {
-      case Server::EnqueueResult::WouldBlock:
-        return send_server_data_many_result_error(env, "would_block");
-      case Server::EnqueueResult::SocketNotFound:
-        return send_server_data_many_result_error(env, "Socket not found");
-      case Server::EnqueueResult::SocketClosed:
-        return send_server_data_many_result_error(env, "Socket is closed or broken");
-      case Server::EnqueueResult::InvalidPayload:
-      default:
-        return send_server_data_many_result_error(env, "Invalid payload");
-    }
+    total_bytes += static_cast<uint64_t>(len);
+    messages.push_back(Server::PendingMessage{std::move(buffer), len});
   }
 
-  if (offset != payload->size) {
+  if (offset != payload->size || messages.empty()) {
     return send_server_data_many_result_error(env, "Invalid batch payload");
   }
 
-  return send_server_data_many_result_ok(env);
+  auto result = state->server->EnqueueBatchData(conn_id, std::move(messages), total_bytes);
+  switch (result) {
+    case Server::EnqueueResult::Ok:
+      return send_server_data_many_result_ok(env);
+    case Server::EnqueueResult::WouldBlock:
+      return send_server_data_many_result_error(env, "would_block");
+    case Server::EnqueueResult::SocketNotFound:
+      return send_server_data_many_result_error(env, "Socket not found");
+    case Server::EnqueueResult::SocketClosed:
+      return send_server_data_many_result_error(env, "Socket is closed or broken");
+    case Server::EnqueueResult::InvalidPayload:
+    default:
+      return send_server_data_many_result_error(env, "Invalid payload");
+  }
 }
 
 UNIFEX_TERM start_client_native(UnifexEnv* env,

--- a/c_src/ex_libsrt/srt_nif.spec.exs
+++ b/c_src/ex_libsrt/srt_nif.spec.exs
@@ -77,10 +77,7 @@ spec send_server_data(conn_id :: int, data :: payload, state) :: (:ok :: label) 
 
 spec stop_server(state) :: (:ok :: label) | {:error :: label, reason :: string}
 
-
-spec start_client(server_address :: string, port :: int, stream_id :: string, password :: string, latency_ms :: int) :: {:ok :: label, state} | {:error :: label, reason :: string, code :: int}
-
-spec start_client_with_mode(server_address :: string, port :: int, stream_id :: string, password :: string, latency_ms :: int, sender_mode :: int) :: {:ok :: label, state} | {:error :: label, reason :: string, code :: int}
+spec start_client_native(server_address :: string, port :: int, stream_id :: string, password :: string, latency_ms :: int, sender_mode :: int) :: {:ok :: label, state} | {:error :: label, reason :: string, code :: int}
 
 spec send_client_data(data :: payload, state) :: (:ok :: label) | {:error :: label, reason :: string}
 
@@ -98,4 +95,4 @@ sends :srt_client_connected :: label
 sends :srt_client_disconnected :: label
 sends {:srt_client_error :: label, reason :: string}
 
-dirty :io,  start_server: 4, close_server_connection: 2, send_server_data: 3, stop_server: 1, start_client: 5, start_client_with_mode: 6, read_server_socket_stats: 2, read_client_socket_stats: 1
+dirty :io,  start_server: 4, close_server_connection: 2, send_server_data: 3, stop_server: 1, start_client_native: 6, read_server_socket_stats: 2, read_client_socket_stats: 1

--- a/c_src/ex_libsrt/srt_nif.spec.exs
+++ b/c_src/ex_libsrt/srt_nif.spec.exs
@@ -80,6 +80,8 @@ spec stop_server(state) :: (:ok :: label) | {:error :: label, reason :: string}
 
 spec start_client(server_address :: string, port :: int, stream_id :: string, password :: string, latency_ms :: int) :: {:ok :: label, state} | {:error :: label, reason :: string, code :: int}
 
+spec start_client_with_mode(server_address :: string, port :: int, stream_id :: string, password :: string, latency_ms :: int, sender_mode :: int) :: {:ok :: label, state} | {:error :: label, reason :: string, code :: int}
+
 spec send_client_data(data :: payload, state) :: (:ok :: label) | {:error :: label, reason :: string}
 
 spec read_client_socket_stats(state) :: {:ok :: label, stats :: srt_socket_stats} | {:error :: label, reason :: string}
@@ -96,4 +98,4 @@ sends :srt_client_connected :: label
 sends :srt_client_disconnected :: label
 sends {:srt_client_error :: label, reason :: string}
 
-dirty :io,  start_server: 4, close_server_connection: 2, send_server_data: 3, stop_server: 1, start_client: 5, read_server_socket_stats: 2, read_client_socket_stats: 1
+dirty :io,  start_server: 4, close_server_connection: 2, send_server_data: 3, stop_server: 1, start_client: 5, start_client_with_mode: 6, read_server_socket_stats: 2, read_client_socket_stats: 1

--- a/c_src/ex_libsrt/srt_nif.spec.exs
+++ b/c_src/ex_libsrt/srt_nif.spec.exs
@@ -73,6 +73,8 @@ spec read_server_socket_stats(conn_id :: int, state) :: {:ok :: label, stats :: 
 
 spec close_server_connection(conn_id :: int, state) :: (:ok :: label) | {:error :: label, reason :: string}
 
+spec send_server_data(conn_id :: int, data :: payload, state) :: (:ok :: label) | {:error :: label, reason :: string}
+
 spec stop_server(state) :: (:ok :: label) | {:error :: label, reason :: string}
 
 
@@ -94,4 +96,4 @@ sends :srt_client_connected :: label
 sends :srt_client_disconnected :: label
 sends {:srt_client_error :: label, reason :: string}
 
-dirty :io,  start_server: 4, close_server_connection: 2, stop_server: 1, start_client: 5, read_server_socket_stats: 2, read_client_socket_stats: 1
+dirty :io,  start_server: 4, close_server_connection: 2, send_server_data: 3, stop_server: 1, start_client: 5, read_server_socket_stats: 2, read_client_socket_stats: 1

--- a/c_src/ex_libsrt/srt_nif.spec.exs
+++ b/c_src/ex_libsrt/srt_nif.spec.exs
@@ -75,6 +75,8 @@ spec close_server_connection(conn_id :: int, state) :: (:ok :: label) | {:error 
 
 spec send_server_data(conn_id :: int, data :: payload, state) :: (:ok :: label) | {:error :: label, reason :: string}
 
+spec send_server_data_many(conn_id :: int, data :: payload, state) :: (:ok :: label) | {:error :: label, reason :: string}
+
 spec stop_server(state) :: (:ok :: label) | {:error :: label, reason :: string}
 
 spec start_client_native(server_address :: string, port :: int, stream_id :: string, password :: string, latency_ms :: int, sender_mode :: int, rcvbuf :: int, udp_rcvbuf :: int, sndbuf :: int, udp_sndbuf :: int) :: {:ok :: label, state} | {:error :: label, reason :: string, code :: int}
@@ -90,6 +92,7 @@ sends {:srt_server_conn_closed:: label, conn :: int}
 sends {:srt_server_error :: label, conn :: int, error :: string}
 sends {:srt_data :: label, conn :: int, data :: payload}
 sends {:srt_server_connect_request :: label, address :: string, stream_id :: string}
+sends {:srt_server_send_telemetry :: label, queue_depth_bytes :: uint64, enqueue_drops :: uint64, send_retries :: uint64, drain_rate_bps :: uint64}
 
 sends :srt_client_connected :: label
 sends :srt_client_disconnected :: label
@@ -99,6 +102,7 @@ dirty :io,
   start_server: 9,
   close_server_connection: 2,
   send_server_data: 3,
+  send_server_data_many: 3,
   stop_server: 1,
   start_client_native: 10,
   send_client_data: 2,

--- a/c_src/ex_libsrt/srt_nif.spec.exs
+++ b/c_src/ex_libsrt/srt_nif.spec.exs
@@ -63,7 +63,7 @@ type srt_socket_stats :: %ExLibSRT.SocketStats{
 callback :load, :on_load
 callback :unload, :on_unload
 
-spec start_server(host :: string, port :: int, password :: string, latency_ms :: int, rcvbuf :: int, udp_rcvbuf :: int, sndbuf :: int, udp_sndbuf :: int) :: {:ok :: label, state} | {:error :: label, reason :: string}
+spec start_server(host :: string, port :: int, password :: string, latency_ms :: int, rcvbuf :: int, udp_rcvbuf :: int, sndbuf :: int, udp_sndbuf :: int, sndtimeo :: int) :: {:ok :: label, state} | {:error :: label, reason :: string}
 
 spec accept_awaiting_connect_request(receiver :: pid, state) :: (:ok :: label) | {:error :: label, reason :: string}
 
@@ -96,7 +96,7 @@ sends :srt_client_disconnected :: label
 sends {:srt_client_error :: label, reason :: string}
 
 dirty :io,
-  start_server: 8,
+  start_server: 9,
   close_server_connection: 2,
   send_server_data: 3,
   stop_server: 1,

--- a/c_src/ex_libsrt/srt_nif.spec.exs
+++ b/c_src/ex_libsrt/srt_nif.spec.exs
@@ -63,7 +63,7 @@ type srt_socket_stats :: %ExLibSRT.SocketStats{
 callback :load, :on_load
 callback :unload, :on_unload
 
-spec start_server(host :: string, port :: int, password :: string, latency_ms :: int) :: {:ok :: label, state} | {:error :: label, reason :: string}
+spec start_server(host :: string, port :: int, password :: string, latency_ms :: int, rcvbuf :: int, udp_rcvbuf :: int, sndbuf :: int, udp_sndbuf :: int) :: {:ok :: label, state} | {:error :: label, reason :: string}
 
 spec accept_awaiting_connect_request(receiver :: pid, state) :: (:ok :: label) | {:error :: label, reason :: string}
 
@@ -77,7 +77,7 @@ spec send_server_data(conn_id :: int, data :: payload, state) :: (:ok :: label) 
 
 spec stop_server(state) :: (:ok :: label) | {:error :: label, reason :: string}
 
-spec start_client_native(server_address :: string, port :: int, stream_id :: string, password :: string, latency_ms :: int, sender_mode :: int) :: {:ok :: label, state} | {:error :: label, reason :: string, code :: int}
+spec start_client_native(server_address :: string, port :: int, stream_id :: string, password :: string, latency_ms :: int, sender_mode :: int, rcvbuf :: int, udp_rcvbuf :: int, sndbuf :: int, udp_sndbuf :: int) :: {:ok :: label, state} | {:error :: label, reason :: string, code :: int}
 
 spec send_client_data(data :: payload, state) :: (:ok :: label) | {:error :: label, reason :: string}
 
@@ -95,4 +95,4 @@ sends :srt_client_connected :: label
 sends :srt_client_disconnected :: label
 sends {:srt_client_error :: label, reason :: string}
 
-dirty :io,  start_server: 4, close_server_connection: 2, send_server_data: 3, stop_server: 1, start_client_native: 6, read_server_socket_stats: 2, read_client_socket_stats: 1
+dirty :io,  start_server: 8, close_server_connection: 2, send_server_data: 3, stop_server: 1, start_client_native: 10, read_server_socket_stats: 2, read_client_socket_stats: 1

--- a/c_src/ex_libsrt/srt_nif.spec.exs
+++ b/c_src/ex_libsrt/srt_nif.spec.exs
@@ -95,4 +95,13 @@ sends :srt_client_connected :: label
 sends :srt_client_disconnected :: label
 sends {:srt_client_error :: label, reason :: string}
 
-dirty :io,  start_server: 8, close_server_connection: 2, send_server_data: 3, stop_server: 1, start_client_native: 10, read_server_socket_stats: 2, read_client_socket_stats: 1
+dirty :io,
+  start_server: 8,
+  close_server_connection: 2,
+  send_server_data: 3,
+  stop_server: 1,
+  start_client_native: 10,
+  send_client_data: 2,
+  read_server_socket_stats: 2,
+  read_client_socket_stats: 1,
+  stop_client: 1

--- a/docs/listener-side-performance-plan.md
+++ b/docs/listener-side-performance-plan.md
@@ -1,0 +1,198 @@
+# Listener-side performance improvement plan (ex_libsrt)
+
+## Goals
+
+1. Increase sustained listener egress throughput (`server -> connected clients`).
+2. Reduce dirty scheduler pressure from send-heavy workloads.
+3. Improve tail latency and resilience under receiver backpressure.
+4. Preserve backwards compatibility of current Elixir API.
+5. Add observability to tune with data, not guesswork.
+
+---
+
+## Phase 0 — Baseline and acceptance gates (before code changes)
+
+### 0.1 Reproducible benchmark matrix
+
+Create three repeatable scenarios:
+
+- **A. Native baseline**: `srt-live-transmit` listener sender -> caller receiver
+- **B. ex_libsrt direct**: `ExLibSRT.Server.send_data/3` hot loop to N clients
+- **C. App path**: real sender app flow (if applicable)
+
+Run each in the same environment class (CPU/memory/network).
+
+### 0.2 Metrics to capture (1s cadence)
+
+- App-layer send throughput (bytes/s, Mbps)
+- Sender SRT stats (`srt_bstats`), especially:
+  - `mbpsSendRate`
+  - `pktSndDrop`
+  - `pktRetrans`
+  - `pktSndLoss`
+- BEAM runtime:
+  - dirty scheduler utilization
+  - reductions
+  - sender process mailbox length
+- Native path (once added):
+  - queue depth (bytes/messages)
+  - enqueue→send latency
+
+### 0.3 Acceptance criteria
+
+- Avg throughput >= **95% of `srt-live-transmit` baseline** for same test.
+- p95 send latency under agreed threshold.
+- No dirty scheduler starvation symptoms.
+
+---
+
+## Phase 1 — Low-risk socket behavior fixes (quick wins)
+
+### 1.1 Enforce non-blocking send semantics
+
+#### Problem
+Listener path does not explicitly ensure egress sockets are configured for non-blocking send behavior.
+
+#### Change
+- Set `SRTO_SNDSYN = 0` on listener/accepted sockets used for egress.
+- Keep `SRTO_RCVSYN = 0` behavior for receive side.
+
+#### Validation
+- Under receiver backpressure, `send_server_data` should not block unexpectedly.
+- Dirty scheduler occupancy should drop in send-heavy tests.
+
+### 1.2 Add send timeout policy
+
+- Set `SRTO_SNDTIMEO` (configurable, sane default e.g. 50–200ms).
+- On timeout, return explicit error/backpressure signal instead of indefinite wait.
+
+### 1.3 Expose key egress tuning options
+
+Add to Native/Elixir options:
+
+- `sndtimeo`
+- `maxbw`
+- `inputbw`
+- `oheadbw`
+- `peerlatency`
+- `rcvlatency`
+- `tlpktdrop`
+
+This narrows the tuning gap with `srt-live-transmit`.
+
+---
+
+## Phase 2 — Architectural fix: native async send pipeline
+
+### 2.1 Add per-connection native send queue
+
+#### Problem
+Current path sends directly inside NIF call (`send_server_data -> srt_sendmsg`), which scales poorly under high message rates and backpressure.
+
+#### Design
+- Each active connection gets a native queue (deque/ring buffer).
+- `send_server_data` enqueues only.
+- Dedicated native sender worker drains queue.
+
+#### Backpressure policy
+- Configurable max queue bytes/messages.
+- Overflow behavior (configurable):
+  - reject enqueue (`{:error, :backpressure}`), or
+  - drop oldest/newest.
+
+### 2.2 OUT-driven writable scheduling
+
+- Register `SRT_EPOLL_OUT` only for sockets with pending queue.
+- Remove `OUT` when queue drains.
+- Keep `IN|ERR` for connection lifecycle handling.
+
+This prevents unnecessary wakeups and avoids busy loops.
+
+### 2.3 API compatibility contract
+
+Keep current API response style (`:ok | {:error, reason}`).
+
+- `:ok` means "queued successfully" in async mode.
+- Optional future events:
+  - `{:srt_server_send_dropped, conn_id, reason}`
+  - `{:srt_server_backpressure, conn_id, queue_depth}`
+
+---
+
+## Phase 3 — NIF/scheduler hygiene
+
+### 3.1 NIF classification by blocking behavior
+
+- Ensure blocking paths remain dirty IO.
+- If enqueue path becomes strictly non-blocking, it may move to normal scheduler later (optional optimization, not day-1).
+
+### 3.2 Allocation minimization on hot path
+
+- Reduce per-send allocations/copies where safe.
+- Consider pooled native buffers for send queues.
+
+---
+
+## Phase 4 — Listener receive/control stability (secondary but related)
+
+### 4.1 Parameterize server read drain batch
+
+- Current fixed receive drain (`max_read_per_cycle`) can be too low/high depending on workload.
+- Make it configurable to reduce wakeup churn.
+
+### 4.2 De-stall accept callback path
+
+- Current accept decision wait can block callback path.
+- Move decision handling off critical section where possible to avoid collateral impact on active flows.
+
+---
+
+## Phase 5 — Observability and tooling
+
+### 5.1 Add listener send telemetry
+
+Emit periodic metrics:
+
+- queue depth per connection (bytes/messages)
+- enqueue failures/backpressure counts
+- bytes queued vs bytes sent
+- sender wakeups and active OUT sockets
+
+### 5.2 Add dedicated listener benchmark scripts
+
+- Compare ex_libsrt listener vs `srt-live-transmit` baseline.
+- Include multi-client fanout tests (1, 2, 5 clients).
+
+---
+
+## Phase 6 — Rollout strategy
+
+### 6.1 Feature flags
+
+- `EX_LIBSRT_SERVER_ASYNC_SEND=true|false`
+- `EX_LIBSRT_SERVER_SNDSYN=false` (target default after validation)
+
+### 6.2 Canary rollout
+
+- Enable on one instance.
+- Compare control vs canary for throughput, drops, retransmissions, scheduler health.
+
+### 6.3 Gradual expansion
+
+- 10% -> 50% -> 100% with monitored gates.
+
+### 6.4 Fast rollback
+
+- Keep sync send path behind flag until async path is proven stable.
+
+---
+
+## Recommended implementation order
+
+1. `SNDSYN` + `SNDTIMEO` + option exposure
+2. Send-path telemetry
+3. Async per-connection queue + OUT-driven drain
+4. Backpressure/error contract refinements
+5. Accept callback de-stall refactor
+
+This ordering delivers quick wins early and contains risk while moving to the high-impact architecture.

--- a/lib/ex_libsrt/client.ex
+++ b/lib/ex_libsrt/client.ex
@@ -3,90 +3,104 @@ defmodule ExLibSRT.Client do
   Implementation of the SRT client.
 
   ## API
-  The client API consinsts of the following functions:
 
-  * `start/3` - starts a client connection to the server
-  * `start/4` - starts a client connection to the server with password authentication
-  * `start_link/3` - starts a client connection to the server and links to current process
-  * `start_link/4` - starts a client connection to the server with password authentication and links to current process
-  * `start_link/5` - starts a client connection to the server with password authentication, sets SRT latency and links to current process
-  * `stop/1` - stops the client connection
-  * `send_data/2` - sends a packet through the client connection
+  Preferred API (keyword options):
 
-  ## Password Authentication
+    * `start/4` - starts a client connection outside a supervision tree
+    * `start_link/4` - starts a client connection and links it to the caller
 
-  When connecting to a server that requires password authentication:
-  - Password must be between 10 and 79 characters long (SRT specification requirement: https://github.com/Haivision/srt/blob/master/docs/API/API-socket-options.md#srto_passphrase)
-  - Empty string means no password authentication (default behavior)
-  - Password must match the server's password
+  Supported options:
 
-  A process starting the client will also receive the following notifications:
-  * `t:srt_client_started/0`
-  * `t:srt_client_disconnected/0`
-  * `t:srt_client_error/0`
+    * `:password` - SRT passphrase (default: `""`)
+    * `:latency_ms` - SRT socket latency in milliseconds (default: `-1`)
+    * `:mode` - `:sender | :receiver` (default: `:sender`)
+
+  Backwards-compatible API (still supported):
+
+    * `start/3`
+    * `start/4` with password as 4th argument
+    * `start_link/3`
+    * `start_link/4` with password as 4th argument
+    * `start_link/5` with password and latency arguments
+
+  A process starting the client will receive the following notifications:
+
+    * `t:srt_client_started/0`
+    * `t:srt_client_disconnected/0`
+    * `t:srt_client_error/0`
   """
 
   use Agent
-  require Logger
+
+  @default_password ""
+  @default_latency_ms -1
+  @default_mode :sender
+  @max_payload_size 1316
 
   @type t :: pid()
-
+  @type mode :: ExLibSRT.Native.client_mode()
   @type srt_client_started :: :srt_client_started
-  @type srt_client_disconnected :: :srt_client_started
+  @type srt_client_disconnected :: :srt_client_disconnected
   @type srt_client_error :: {:srt_client_error, reason :: String.t()}
+
+  @type start_opt ::
+          {:password, String.t()}
+          | {:latency_ms, integer()}
+          | {:mode, mode()}
+
+  @type start_opts :: [start_opt()]
 
   @doc """
   Starts a new SRT connection to the target address and port and links to the current process.
 
-  ## Password Authentication
-
-  If a password is provided, it must be between 10 and 79 characters long according to SRT specification.
-  An empty string means no password authentication will be used.
+  This function supports both modern options-based calls and backwards-compatible positional args.
   """
-  @spec start_link(
-          address :: String.t(),
-          port :: non_neg_integer(),
-          stream_id :: String.t(),
-          password :: String.t(),
-          latency_ms :: integer()
-        ) ::
-          {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
-  def start_link(address, port, stream_id, password \\ "", latency_ms \\ -1) do
-    with :ok <- validate_password(password),
-         {:ok, client_ref} <-
-           ExLibSRT.Native.start_client(address, port, stream_id, password, latency_ms) do
-      Agent.start_link(fn -> client_ref end)
-    else
-      {:error, reason, error_code} -> {:error, reason, error_code}
-      {:error, reason} -> {:error, reason, 0}
-    end
+  @spec start_link(String.t(), non_neg_integer(), String.t()) ::
+          {:ok, t()} | {:error, String.t(), integer()}
+  @spec start_link(String.t(), non_neg_integer(), String.t(), String.t()) ::
+          {:ok, t()} | {:error, String.t(), integer()}
+  @spec start_link(String.t(), non_neg_integer(), String.t(), String.t(), integer()) ::
+          {:ok, t()} | {:error, String.t(), integer()}
+  @spec start_link(String.t(), non_neg_integer(), String.t(), start_opts()) ::
+          {:ok, t()} | {:error, String.t(), integer()}
+  def start_link(address, port, stream_id) do
+    start_link(address, port, stream_id, [])
+  end
+
+  def start_link(address, port, stream_id, password) when is_binary(password) do
+    start_link(address, port, stream_id, password, @default_latency_ms)
+  end
+
+  def start_link(address, port, stream_id, opts) when is_list(opts) do
+    do_start_link(address, port, stream_id, opts)
+  end
+
+  def start_link(address, port, stream_id, password, latency_ms)
+      when is_binary(password) and is_integer(latency_ms) do
+    do_start_link(address, port, stream_id, password: password, latency_ms: latency_ms)
   end
 
   @doc """
   Starts a new SRT connection to the target address and port outside the supervision tree.
 
-  ## Password Authentication
-
-  If a password is provided, it must be between 10 and 79 characters long according to SRT specification.
-  An empty string means no password authentication will be used.
+  This function supports both modern options-based calls and backwards-compatible positional args.
   """
-  @spec start(address :: String.t(), port :: non_neg_integer(), stream_id :: String.t()) ::
-          {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
-  @spec start(
-          address :: String.t(),
-          port :: non_neg_integer(),
-          stream_id :: String.t(),
-          password :: String.t()
-        ) ::
-          {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
-  def start(address, port, stream_id, password \\ "") do
-    with :ok <- validate_password(password),
-         {:ok, client_ref} <- ExLibSRT.Native.start_client(address, port, stream_id, password, -1) do
-      Agent.start(fn -> client_ref end, name: {:global, client_ref})
-    else
-      {:error, reason, error_code} -> {:error, reason, error_code}
-      {:error, reason} -> {:error, reason, 0}
-    end
+  @spec start(String.t(), non_neg_integer(), String.t()) ::
+          {:ok, t()} | {:error, String.t(), integer()}
+  @spec start(String.t(), non_neg_integer(), String.t(), String.t()) ::
+          {:ok, t()} | {:error, String.t(), integer()}
+  @spec start(String.t(), non_neg_integer(), String.t(), start_opts()) ::
+          {:ok, t()} | {:error, String.t(), integer()}
+  def start(address, port, stream_id) do
+    start(address, port, stream_id, [])
+  end
+
+  def start(address, port, stream_id, password) when is_binary(password) do
+    do_start(address, port, stream_id, password: password)
+  end
+
+  def start(address, port, stream_id, opts) when is_list(opts) do
+    do_start(address, port, stream_id, opts)
   end
 
   @doc """
@@ -102,10 +116,9 @@ defmodule ExLibSRT.Client do
   @doc """
   Sends data through the client connection.
   """
-  @spec send_data(binary(), t()) :: :ok | {:error, :payload_too_large | (reason :: String.t())}
-  def send_data(payload, agent)
-
-  def send_data(payload, _agent) when byte_size(payload) > 1316, do: {:error, :payload_too_large}
+  @spec send_data(binary(), t()) :: :ok | {:error, :payload_too_large | String.t()}
+  def send_data(payload, _agent) when byte_size(payload) > @max_payload_size,
+    do: {:error, :payload_too_large}
 
   def send_data(payload, agent) do
     if Process.alive?(agent) do
@@ -119,8 +132,7 @@ defmodule ExLibSRT.Client do
   @doc """
   Reads socket statistics.
   """
-  @spec read_socket_stats(t()) ::
-          {:ok, ExLibSRT.SocketStats.t()} | {:error, reason :: String.t()}
+  @spec read_socket_stats(t()) :: {:ok, ExLibSRT.SocketStats.t()} | {:error, String.t()}
   def read_socket_stats(agent) do
     if Process.alive?(agent) do
       client_ref = Agent.get(agent, & &1)
@@ -130,7 +142,77 @@ defmodule ExLibSRT.Client do
     end
   end
 
-  # Private functions
+  defp do_start_link(address, port, stream_id, opts) do
+    with {:ok, normalized_opts} <- normalize_start_opts(opts),
+         :ok <- validate_password(normalized_opts.password),
+         {:ok, client_ref} <- start_native_client(address, port, stream_id, normalized_opts) do
+      Agent.start_link(fn -> client_ref end)
+    else
+      {:error, reason, error_code} -> {:error, reason, error_code}
+      {:error, reason} -> {:error, reason, 0}
+    end
+  end
+
+  defp do_start(address, port, stream_id, opts) do
+    with {:ok, normalized_opts} <- normalize_start_opts(opts),
+         :ok <- validate_password(normalized_opts.password),
+         {:ok, client_ref} <- start_native_client(address, port, stream_id, normalized_opts) do
+      Agent.start(fn -> client_ref end, name: {:global, client_ref})
+    else
+      {:error, reason, error_code} -> {:error, reason, error_code}
+      {:error, reason} -> {:error, reason, 0}
+    end
+  end
+
+  defp start_native_client(address, port, stream_id, opts) do
+    ExLibSRT.Native.start_client(
+      address,
+      port,
+      stream_id,
+      opts.password,
+      opts.latency_ms,
+      opts.mode
+    )
+  end
+
+  defp normalize_start_opts(opts) when is_list(opts) do
+    if Keyword.keyword?(opts) do
+      with {:ok, _validated_opts} <- Keyword.validate(opts, [:password, :latency_ms, :mode]),
+           latency_ms <- Keyword.get(opts, :latency_ms, @default_latency_ms),
+           :ok <- validate_latency_ms(latency_ms),
+           mode <- Keyword.get(opts, :mode, @default_mode),
+           :ok <- validate_mode(mode) do
+        {:ok,
+         %{
+           password: Keyword.get(opts, :password, @default_password),
+           latency_ms: latency_ms,
+           mode: mode
+         }}
+      else
+        {:error, invalid_keys} when is_list(invalid_keys) ->
+          {:error,
+           "Unsupported client options: " <>
+             Enum.map_join(invalid_keys, ", ", &inspect/1)}
+
+        {:error, _reason} = error ->
+          error
+      end
+    else
+      {:error, "Client options must be a keyword list"}
+    end
+  end
+
+  defp normalize_start_opts(_opts), do: {:error, "Client options must be a keyword list"}
+
+  defp validate_latency_ms(latency_ms) when is_integer(latency_ms), do: :ok
+
+  defp validate_latency_ms(latency_ms),
+    do: {:error, "Latency must be an integer, got: #{inspect(latency_ms)}"}
+
+  defp validate_mode(mode) when mode in [:sender, :receiver], do: :ok
+
+  defp validate_mode(mode),
+    do: {:error, "Invalid client mode #{inspect(mode)}. Expected :sender or :receiver."}
 
   @spec validate_password(String.t()) :: :ok | {:error, String.t()}
   defp validate_password(""), do: :ok

--- a/lib/ex_libsrt/client.ex
+++ b/lib/ex_libsrt/client.ex
@@ -53,7 +53,19 @@ defmodule ExLibSRT.Client do
   @doc """
   Starts a new SRT connection to the target address and port and links to the current process.
 
-  This function supports both modern options-based calls and backwards-compatible positional args.
+  Use the options-based variant for clarity:
+
+      ExLibSRT.Client.start_link("127.0.0.1", 12_000, "stream-id",
+        password: "",
+        latency_ms: -1,
+        mode: :sender
+      )
+
+  Mode controls socket behavior:
+  - `:sender` (default) is for pushing payloads with `send_data/2`
+  - `:receiver` is for consuming incoming `{:srt_data, conn_id, payload}` messages
+
+  Positional overloads are still supported for backwards compatibility.
   """
   @spec start_link(String.t(), non_neg_integer(), String.t()) ::
           {:ok, t()} | {:error, String.t(), integer()}
@@ -83,7 +95,13 @@ defmodule ExLibSRT.Client do
   @doc """
   Starts a new SRT connection to the target address and port outside the supervision tree.
 
-  This function supports both modern options-based calls and backwards-compatible positional args.
+  This is equivalent to `start_link/4`, but does not link the client process to the caller.
+
+  Prefer the options-based variant:
+
+      ExLibSRT.Client.start("127.0.0.1", 12_000, "stream-id", mode: :receiver)
+
+  Positional overloads are still supported for backwards compatibility.
   """
   @spec start(String.t(), non_neg_integer(), String.t()) ::
           {:ok, t()} | {:error, String.t(), integer()}

--- a/lib/ex_libsrt/client.ex
+++ b/lib/ex_libsrt/client.ex
@@ -14,6 +14,10 @@ defmodule ExLibSRT.Client do
     * `:password` - SRT passphrase (default: `""`)
     * `:latency_ms` - SRT socket latency in milliseconds (default: `-1`)
     * `:mode` - `:sender | :receiver` (default: `:sender`)
+    * `:rcvbuf` - SRT-level receive buffer in bytes (`SRTO_RCVBUF`)
+    * `:udp_rcvbuf` - OS kernel UDP receive buffer in bytes (`SRTO_UDP_RCVBUF`)
+    * `:sndbuf` - SRT-level send buffer in bytes (`SRTO_SNDBUF`)
+    * `:udp_sndbuf` - OS kernel UDP send buffer in bytes (`SRTO_UDP_SNDBUF`)
 
   Backwards-compatible API (still supported):
 
@@ -47,6 +51,10 @@ defmodule ExLibSRT.Client do
           {:password, String.t()}
           | {:latency_ms, integer()}
           | {:mode, mode()}
+          | {:rcvbuf, pos_integer()}
+          | {:udp_rcvbuf, pos_integer()}
+          | {:sndbuf, pos_integer()}
+          | {:udp_sndbuf, pos_integer()}
 
   @type start_opts :: [start_opt()]
 
@@ -189,22 +197,29 @@ defmodule ExLibSRT.Client do
       stream_id,
       opts.password,
       opts.latency_ms,
-      opts.mode
+      opts.mode,
+      opts.socket_opts
     )
   end
 
+  @known_opts [:password, :latency_ms, :mode, :rcvbuf, :udp_rcvbuf, :sndbuf, :udp_sndbuf]
+
   defp normalize_start_opts(opts) when is_list(opts) do
     if Keyword.keyword?(opts) do
-      with {:ok, _validated_opts} <- Keyword.validate(opts, [:password, :latency_ms, :mode]),
+      with {:ok, _validated_opts} <- Keyword.validate(opts, @known_opts),
            latency_ms <- Keyword.get(opts, :latency_ms, @default_latency_ms),
            :ok <- validate_latency_ms(latency_ms),
            mode <- Keyword.get(opts, :mode, @default_mode),
-           :ok <- validate_mode(mode) do
+           :ok <- validate_mode(mode),
+           :ok <- validate_buffer_opts(opts) do
         {:ok,
          %{
            password: Keyword.get(opts, :password, @default_password),
            latency_ms: latency_ms,
-           mode: mode
+           mode: mode,
+           socket_opts:
+             opts
+             |> Keyword.take([:rcvbuf, :udp_rcvbuf, :sndbuf, :udp_sndbuf])
          }}
       else
         {:error, invalid_keys} when is_list(invalid_keys) ->
@@ -231,6 +246,23 @@ defmodule ExLibSRT.Client do
 
   defp validate_mode(mode),
     do: {:error, "Invalid client mode #{inspect(mode)}. Expected :sender or :receiver."}
+
+  @buffer_opt_keys [:rcvbuf, :udp_rcvbuf, :sndbuf, :udp_sndbuf]
+
+  defp validate_buffer_opts(opts) do
+    Enum.reduce_while(@buffer_opt_keys, :ok, fn key, :ok ->
+      case Keyword.fetch(opts, key) do
+        :error ->
+          {:cont, :ok}
+
+        {:ok, val} when is_integer(val) and val > 0 ->
+          {:cont, :ok}
+
+        {:ok, val} ->
+          {:halt, {:error, "#{key} must be a positive integer, got: #{inspect(val)}"}}
+      end
+    end)
+  end
 
   @spec validate_password(String.t()) :: :ok | {:error, String.t()}
   defp validate_password(""), do: :ok

--- a/lib/ex_libsrt/native.ex
+++ b/lib/ex_libsrt/native.ex
@@ -7,10 +7,27 @@ defmodule ExLibSRT.Native do
   use Unifex.Loader
 
   @doc """
-  Starts an SRT client using an atom-based client mode.
+  Starts an SRT client in `:sender` mode.
 
-  This is a developer-friendly wrapper around the native
-  `start_client_with_mode/6` function.
+  Use this when the client is expected to push data to the remote SRT listener,
+  for example when calling `send_client_data/2`.
+  """
+  @spec start_client(String.t(), non_neg_integer(), String.t(), String.t(), integer()) ::
+          {:ok, reference()} | {:error, String.t(), integer()}
+  def start_client(address, port, stream_id, password, latency_ms) do
+    start_client(address, port, stream_id, password, latency_ms, :sender)
+  end
+
+  @doc """
+  Starts an SRT client with an explicit `mode` (`:sender` or `:receiver`).
+
+  This is the developer-friendly client startup API used by higher-level modules.
+
+  It converts the Elixir atom mode to the native `sender_mode` flag internally,
+  so callers never need to pass raw integers (`1` / `0`).
+
+  - Use `:sender` when the client should send payloads with `send_client_data/2`.
+  - Use `:receiver` when the client should consume incoming `{:srt_data, ...}` messages.
   """
   @spec start_client(
           String.t(),
@@ -25,7 +42,7 @@ defmodule ExLibSRT.Native do
       when mode in [:sender, :receiver] do
     sender_mode = if mode == :sender, do: 1, else: 0
 
-    start_client_with_mode(
+    start_client_native(
       address,
       port,
       stream_id,

--- a/lib/ex_libsrt/native.ex
+++ b/lib/ex_libsrt/native.ex
@@ -1,4 +1,41 @@
 defmodule ExLibSRT.Native do
   @moduledoc false
+
+  @typedoc "SRT client socket mode."
+  @type client_mode :: :sender | :receiver
+
   use Unifex.Loader
+
+  @doc """
+  Starts an SRT client using an atom-based client mode.
+
+  This is a developer-friendly wrapper around the native
+  `start_client_with_mode/6` function.
+  """
+  @spec start_client(
+          String.t(),
+          non_neg_integer(),
+          String.t(),
+          String.t(),
+          integer(),
+          client_mode()
+        ) ::
+          {:ok, reference()} | {:error, String.t(), integer()}
+  def start_client(address, port, stream_id, password, latency_ms, mode)
+      when mode in [:sender, :receiver] do
+    sender_mode = if mode == :sender, do: 1, else: 0
+
+    start_client_with_mode(
+      address,
+      port,
+      stream_id,
+      password,
+      latency_ms,
+      sender_mode
+    )
+  end
+
+  def start_client(_address, _port, _stream_id, _password, _latency_ms, mode) do
+    {:error, "Invalid client mode #{inspect(mode)}. Expected :sender or :receiver.", 0}
+  end
 end

--- a/lib/ex_libsrt/native.ex
+++ b/lib/ex_libsrt/native.ex
@@ -14,12 +14,14 @@ defmodule ExLibSRT.Native do
     * `:udp_rcvbuf`  – OS kernel UDP receive buffer (`SRTO_UDP_RCVBUF`, default ~8 MB)
     * `:sndbuf`      – SRT-level send buffer (`SRTO_SNDBUF`, default ~12 MB)
     * `:udp_sndbuf`  – OS kernel UDP send buffer (`SRTO_UDP_SNDBUF`, default ~64 KB)
+    * `:sndtimeo`    – send timeout in ms (`SRTO_SNDTIMEO`, default SRT value)
   """
   @type socket_opt ::
           {:rcvbuf, pos_integer()}
           | {:udp_rcvbuf, pos_integer()}
           | {:sndbuf, pos_integer()}
           | {:udp_sndbuf, pos_integer()}
+          | {:sndtimeo, non_neg_integer()}
 
   @type socket_opts :: [socket_opt()]
 
@@ -120,7 +122,8 @@ defmodule ExLibSRT.Native do
       Keyword.get(socket_opts, :rcvbuf, -1),
       Keyword.get(socket_opts, :udp_rcvbuf, -1),
       Keyword.get(socket_opts, :sndbuf, -1),
-      Keyword.get(socket_opts, :udp_sndbuf, -1)
+      Keyword.get(socket_opts, :udp_sndbuf, -1),
+      Keyword.get(socket_opts, :sndtimeo, -1)
     )
   end
 end

--- a/lib/ex_libsrt/native.ex
+++ b/lib/ex_libsrt/native.ex
@@ -4,30 +4,38 @@ defmodule ExLibSRT.Native do
   @typedoc "SRT client socket mode."
   @type client_mode :: :sender | :receiver
 
+  @typedoc """
+  SRT socket buffer options.
+
+  All values are in bytes. A value of `-1` (or omission) means
+  "use the SRT library default".
+
+    * `:rcvbuf`      – SRT-level receive buffer (`SRTO_RCVBUF`, default ~12 MB)
+    * `:udp_rcvbuf`  – OS kernel UDP receive buffer (`SRTO_UDP_RCVBUF`, default ~8 MB)
+    * `:sndbuf`      – SRT-level send buffer (`SRTO_SNDBUF`, default ~12 MB)
+    * `:udp_sndbuf`  – OS kernel UDP send buffer (`SRTO_UDP_SNDBUF`, default ~64 KB)
+  """
+  @type socket_opt ::
+          {:rcvbuf, pos_integer()}
+          | {:udp_rcvbuf, pos_integer()}
+          | {:sndbuf, pos_integer()}
+          | {:udp_sndbuf, pos_integer()}
+
+  @type socket_opts :: [socket_opt()]
+
   use Unifex.Loader
 
   @doc """
-  Starts an SRT client in `:sender` mode.
-
-  Use this when the client is expected to push data to the remote SRT listener,
-  for example when calling `send_client_data/2`.
+  Starts an SRT client in `:sender` mode with default socket options.
   """
   @spec start_client(String.t(), non_neg_integer(), String.t(), String.t(), integer()) ::
           {:ok, reference()} | {:error, String.t(), integer()}
   def start_client(address, port, stream_id, password, latency_ms) do
-    start_client(address, port, stream_id, password, latency_ms, :sender)
+    start_client(address, port, stream_id, password, latency_ms, :sender, [])
   end
 
   @doc """
-  Starts an SRT client with an explicit `mode` (`:sender` or `:receiver`).
-
-  This is the developer-friendly client startup API used by higher-level modules.
-
-  It converts the Elixir atom mode to the native `sender_mode` flag internally,
-  so callers never need to pass raw integers (`1` / `0`).
-
-  - Use `:sender` when the client should send payloads with `send_client_data/2`.
-  - Use `:receiver` when the client should consume incoming `{:srt_data, ...}` messages.
+  Starts an SRT client with an explicit `mode` and default socket options.
   """
   @spec start_client(
           String.t(),
@@ -40,6 +48,31 @@ defmodule ExLibSRT.Native do
           {:ok, reference()} | {:error, String.t(), integer()}
   def start_client(address, port, stream_id, password, latency_ms, mode)
       when mode in [:sender, :receiver] do
+    start_client(address, port, stream_id, password, latency_ms, mode, [])
+  end
+
+  def start_client(_address, _port, _stream_id, _password, _latency_ms, mode) do
+    {:error, "Invalid client mode #{inspect(mode)}. Expected :sender or :receiver.", 0}
+  end
+
+  @doc """
+  Starts an SRT client with an explicit `mode` and socket buffer options.
+
+  `socket_opts` is a keyword list of buffer sizes (see `t:socket_opts/0`).
+  Omitted keys default to `-1` (SRT library default).
+  """
+  @spec start_client(
+          String.t(),
+          non_neg_integer(),
+          String.t(),
+          String.t(),
+          integer(),
+          client_mode(),
+          socket_opts()
+        ) ::
+          {:ok, reference()} | {:error, String.t(), integer()}
+  def start_client(address, port, stream_id, password, latency_ms, mode, socket_opts)
+      when mode in [:sender, :receiver] and is_list(socket_opts) do
     sender_mode = if mode == :sender, do: 1, else: 0
 
     start_client_native(
@@ -48,11 +81,46 @@ defmodule ExLibSRT.Native do
       stream_id,
       password,
       latency_ms,
-      sender_mode
+      sender_mode,
+      Keyword.get(socket_opts, :rcvbuf, -1),
+      Keyword.get(socket_opts, :udp_rcvbuf, -1),
+      Keyword.get(socket_opts, :sndbuf, -1),
+      Keyword.get(socket_opts, :udp_sndbuf, -1)
     )
   end
 
-  def start_client(_address, _port, _stream_id, _password, _latency_ms, mode) do
+  def start_client(_address, _port, _stream_id, _password, _latency_ms, mode, _socket_opts) do
     {:error, "Invalid client mode #{inspect(mode)}. Expected :sender or :receiver.", 0}
+  end
+
+  @doc """
+  Starts an SRT server with default socket options.
+  """
+  @spec start_server(String.t(), non_neg_integer(), String.t(), integer()) ::
+          {:ok, reference()} | {:error, String.t()}
+  def start_server(address, port, password, latency_ms) do
+    start_server(address, port, password, latency_ms, [])
+  end
+
+  @doc """
+  Starts an SRT server with socket buffer options.
+
+  `socket_opts` is a keyword list of buffer sizes (see `t:socket_opts/0`).
+  Omitted keys default to `-1` (SRT library default).
+  """
+  @spec start_server(String.t(), non_neg_integer(), String.t(), integer(), socket_opts()) ::
+          {:ok, reference()} | {:error, String.t()}
+  def start_server(address, port, password, latency_ms, socket_opts)
+      when is_list(socket_opts) do
+    start_server(
+      address,
+      port,
+      password,
+      latency_ms,
+      Keyword.get(socket_opts, :rcvbuf, -1),
+      Keyword.get(socket_opts, :udp_rcvbuf, -1),
+      Keyword.get(socket_opts, :sndbuf, -1),
+      Keyword.get(socket_opts, :udp_sndbuf, -1)
+    )
   end
 end

--- a/lib/ex_libsrt/server.ex
+++ b/lib/ex_libsrt/server.ex
@@ -30,6 +30,7 @@ defmodule ExLibSRT.Server do
   * `t:srt_data/0` - server has received new data on a client connection
   * `t:srt_server_connect_request/0` - server has triggered a new connection request
     (see `accept_awaiting_connect_request/1` and `reject_awaiting_connect_request/1` for answering the request)
+  * `t:srt_server_send_telemetry/0` - queue depth / drops / retries / drain rate from native sender worker
 
   ### Accepting connections
   Each SRT connection can carry a `streamid` string which can be used for identifying the stream.
@@ -62,6 +63,10 @@ defmodule ExLibSRT.Server do
   @type srt_data :: {:srt_data, connection_id(), data :: binary()}
   @type srt_server_connect_request ::
           {:srt_server_connect_request, address :: String.t(), stream_id :: String.t()}
+
+  @type srt_server_send_telemetry ::
+          {:srt_server_send_telemetry, non_neg_integer(), non_neg_integer(), non_neg_integer(),
+           non_neg_integer()}
 
   @type start_opt ::
           {:password, String.t()}
@@ -227,7 +232,7 @@ defmodule ExLibSRT.Server do
   Sends data through a server connection.
   """
   @spec send_data(connection_id(), binary(), t()) ::
-          :ok | {:error, :payload_too_large | (reason :: String.t())}
+          :ok | {:error, :payload_too_large | :would_block | (reason :: String.t())}
   def send_data(connection_id, payload, agent)
 
   def send_data(_connection_id, payload, _agent) when byte_size(payload) > @max_payload_size,
@@ -236,9 +241,49 @@ defmodule ExLibSRT.Server do
   def send_data(connection_id, payload, agent) do
     if Process.alive?(agent) do
       server_ref = Agent.get(agent, & &1)
-      ExLibSRT.Native.send_server_data(connection_id, payload, server_ref)
+
+      connection_id
+      |> ExLibSRT.Native.send_server_data(payload, server_ref)
+      |> map_send_error()
     else
       {:error, "Server is not active"}
+    end
+  end
+
+  @doc """
+  Sends many payloads through a server connection using one NIF call.
+
+  This reduces BEAM↔NIF crossing overhead on hot sender paths.
+  """
+  @spec send_data_many(connection_id(), [binary()], t()) ::
+          :ok | {:error, :payload_too_large | :would_block | (reason :: String.t())}
+  def send_data_many(connection_id, payloads, agent)
+
+  def send_data_many(_connection_id, payloads, _agent) when not is_list(payloads),
+    do: {:error, "payloads must be a list of binaries"}
+
+  def send_data_many(connection_id, payloads, agent) do
+    cond do
+      not Enum.all?(payloads, &is_binary/1) ->
+        {:error, "payloads must be a list of binaries"}
+
+      Enum.any?(payloads, &(byte_size(&1) > @max_payload_size)) ->
+        {:error, :payload_too_large}
+
+      Process.alive?(agent) ->
+        server_ref = Agent.get(agent, & &1)
+
+        framed =
+          Enum.reduce(payloads, <<>>, fn payload, acc ->
+            <<acc::binary, byte_size(payload)::16-big-unsigned-integer, payload::binary>>
+          end)
+
+        connection_id
+        |> ExLibSRT.Native.send_server_data_many(framed, server_ref)
+        |> map_send_error()
+
+      true ->
+        {:error, "Server is not active"}
     end
   end
 
@@ -351,6 +396,9 @@ defmodule ExLibSRT.Server do
         {:error, ":sndtimeo must be a non-negative integer, got: #{inspect(val)}"}
     end
   end
+
+  defp map_send_error({:error, "would_block"}), do: {:error, :would_block}
+  defp map_send_error(other), do: other
 
   @spec validate_password(String.t()) :: :ok | {:error, String.t()}
   defp validate_password(""), do: :ok

--- a/lib/ex_libsrt/server.ex
+++ b/lib/ex_libsrt/server.ex
@@ -63,16 +63,51 @@ defmodule ExLibSRT.Server do
   @type srt_server_connect_request ::
           {:srt_server_connect_request, address :: String.t(), stream_id :: String.t()}
 
+  @type start_opt ::
+          {:password, String.t()}
+          | {:latency_ms, integer()}
+          | {:rcvbuf, pos_integer()}
+          | {:udp_rcvbuf, pos_integer()}
+          | {:sndbuf, pos_integer()}
+          | {:udp_sndbuf, pos_integer()}
+
+  @type start_opts :: [start_opt()]
+
   @doc """
   Starts a new SRT server binding to given address and port and links to current process.
 
   One may usually want to bind to `0.0.0.0` address.
+
+  ## Options
+
+    * `:password` - SRT passphrase (default: `""`)
+    * `:latency_ms` - SRT socket latency in milliseconds (default: `-1`)
+    * `:rcvbuf` - SRT-level receive buffer in bytes (`SRTO_RCVBUF`)
+    * `:udp_rcvbuf` - OS kernel UDP receive buffer in bytes (`SRTO_UDP_RCVBUF`)
+    * `:sndbuf` - SRT-level send buffer in bytes (`SRTO_SNDBUF`)
+    * `:udp_sndbuf` - OS kernel UDP send buffer in bytes (`SRTO_UDP_SNDBUF`)
 
   ## Password Requirements
 
   If a password is provided, it must be between 10 and 79 characters long according to SRT specification.
   An empty string means no password authentication will be used.
   """
+  @spec start_link(address :: String.t(), port :: non_neg_integer()) ::
+          {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
+  def start_link(address, port) do
+    do_start_link(address, port, [])
+  end
+
+  @spec start_link(address :: String.t(), port :: non_neg_integer(), String.t() | start_opts()) ::
+          {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
+  def start_link(address, port, password) when is_binary(password) do
+    do_start_link(address, port, password: password)
+  end
+
+  def start_link(address, port, opts) when is_list(opts) do
+    do_start_link(address, port, opts)
+  end
+
   @spec start_link(
           address :: String.t(),
           port :: non_neg_integer(),
@@ -80,20 +115,17 @@ defmodule ExLibSRT.Server do
           latency_ms :: integer()
         ) ::
           {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
-  def start_link(address, port, password \\ "", latency_ms \\ -1) do
-    with :ok <- validate_password(password),
-         {:ok, server_ref} <- ExLibSRT.Native.start_server(address, port, password, latency_ms) do
-      Agent.start_link(fn -> server_ref end)
-    else
-      {:error, reason, error_code} -> {:error, reason, error_code}
-      {:error, reason} -> {:error, reason, 0}
-    end
+  def start_link(address, port, password, latency_ms)
+      when is_binary(password) and is_integer(latency_ms) do
+    do_start_link(address, port, password: password, latency_ms: latency_ms)
   end
 
   @doc """
   Starts a new SRT server outside the supervision tree, binding to given address and port.
 
   One may usually want to bind to `0.0.0.0` address.
+
+  Accepts the same options as `start_link/3`.
 
   ## Password Requirements
 
@@ -102,16 +134,18 @@ defmodule ExLibSRT.Server do
   """
   @spec start(address :: String.t(), port :: non_neg_integer()) ::
           {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
-  @spec start(address :: String.t(), port :: non_neg_integer(), password :: String.t()) ::
+  def start(address, port) do
+    do_start(address, port, [])
+  end
+
+  @spec start(address :: String.t(), port :: non_neg_integer(), String.t() | start_opts()) ::
           {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
-  def start(address, port, password \\ "") do
-    with :ok <- validate_password(password),
-         {:ok, server_ref} <- ExLibSRT.Native.start_server(address, port, password, -1) do
-      Agent.start(fn -> server_ref end, name: {:global, server_ref})
-    else
-      {:error, reason, error_code} -> {:error, reason, error_code}
-      {:error, reason} -> {:error, reason, 0}
-    end
+  def start(address, port, password) when is_binary(password) do
+    do_start(address, port, password: password)
+  end
+
+  def start(address, port, opts) when is_list(opts) do
+    do_start(address, port, opts)
   end
 
   @doc """
@@ -221,6 +255,85 @@ defmodule ExLibSRT.Server do
   end
 
   # Private functions
+
+  @known_opts [:password, :latency_ms, :rcvbuf, :udp_rcvbuf, :sndbuf, :udp_sndbuf]
+
+  defp do_start_link(address, port, opts) do
+    with {:ok, normalized} <- normalize_start_opts(opts),
+         :ok <- validate_password(normalized.password),
+         {:ok, server_ref} <-
+           ExLibSRT.Native.start_server(
+             address,
+             port,
+             normalized.password,
+             normalized.latency_ms,
+             normalized.socket_opts
+           ) do
+      Agent.start_link(fn -> server_ref end)
+    else
+      {:error, reason, error_code} -> {:error, reason, error_code}
+      {:error, reason} -> {:error, reason, 0}
+    end
+  end
+
+  defp do_start(address, port, opts) do
+    with {:ok, normalized} <- normalize_start_opts(opts),
+         :ok <- validate_password(normalized.password),
+         {:ok, server_ref} <-
+           ExLibSRT.Native.start_server(
+             address,
+             port,
+             normalized.password,
+             normalized.latency_ms,
+             normalized.socket_opts
+           ) do
+      Agent.start(fn -> server_ref end, name: {:global, server_ref})
+    else
+      {:error, reason, error_code} -> {:error, reason, error_code}
+      {:error, reason} -> {:error, reason, 0}
+    end
+  end
+
+  defp normalize_start_opts(opts) when is_list(opts) do
+    if Keyword.keyword?(opts) do
+      with {:ok, _} <- Keyword.validate(opts, @known_opts),
+           :ok <- validate_buffer_opts(opts) do
+        {:ok,
+         %{
+           password: Keyword.get(opts, :password, ""),
+           latency_ms: Keyword.get(opts, :latency_ms, -1),
+           socket_opts: Keyword.take(opts, [:rcvbuf, :udp_rcvbuf, :sndbuf, :udp_sndbuf])
+         }}
+      else
+        {:error, invalid_keys} when is_list(invalid_keys) ->
+          {:error,
+           "Unsupported server options: " <>
+             Enum.map_join(invalid_keys, ", ", &inspect/1)}
+
+        {:error, _reason} = error ->
+          error
+      end
+    else
+      {:error, "Server options must be a keyword list"}
+    end
+  end
+
+  @buffer_opt_keys [:rcvbuf, :udp_rcvbuf, :sndbuf, :udp_sndbuf]
+
+  defp validate_buffer_opts(opts) do
+    Enum.reduce_while(@buffer_opt_keys, :ok, fn key, :ok ->
+      case Keyword.fetch(opts, key) do
+        :error ->
+          {:cont, :ok}
+
+        {:ok, val} when is_integer(val) and val > 0 ->
+          {:cont, :ok}
+
+        {:ok, val} ->
+          {:halt, {:error, "#{key} must be a positive integer, got: #{inspect(val)}"}}
+      end
+    end)
+  end
 
   @spec validate_password(String.t()) :: :ok | {:error, String.t()}
   defp validate_password(""), do: :ok

--- a/lib/ex_libsrt/server.ex
+++ b/lib/ex_libsrt/server.ex
@@ -70,6 +70,7 @@ defmodule ExLibSRT.Server do
           | {:udp_rcvbuf, pos_integer()}
           | {:sndbuf, pos_integer()}
           | {:udp_sndbuf, pos_integer()}
+          | {:sndtimeo, non_neg_integer()}
 
   @type start_opts :: [start_opt()]
 
@@ -86,6 +87,7 @@ defmodule ExLibSRT.Server do
     * `:udp_rcvbuf` - OS kernel UDP receive buffer in bytes (`SRTO_UDP_RCVBUF`)
     * `:sndbuf` - SRT-level send buffer in bytes (`SRTO_SNDBUF`)
     * `:udp_sndbuf` - OS kernel UDP send buffer in bytes (`SRTO_UDP_SNDBUF`)
+    * `:sndtimeo` - send timeout in milliseconds (`SRTO_SNDTIMEO`)
 
   ## Password Requirements
 
@@ -256,7 +258,7 @@ defmodule ExLibSRT.Server do
 
   # Private functions
 
-  @known_opts [:password, :latency_ms, :rcvbuf, :udp_rcvbuf, :sndbuf, :udp_sndbuf]
+  @known_opts [:password, :latency_ms, :rcvbuf, :udp_rcvbuf, :sndbuf, :udp_sndbuf, :sndtimeo]
 
   defp do_start_link(address, port, opts) do
     with {:ok, normalized} <- normalize_start_opts(opts),
@@ -297,12 +299,14 @@ defmodule ExLibSRT.Server do
   defp normalize_start_opts(opts) when is_list(opts) do
     if Keyword.keyword?(opts) do
       with {:ok, _} <- Keyword.validate(opts, @known_opts),
-           :ok <- validate_buffer_opts(opts) do
+           :ok <- validate_buffer_opts(opts),
+           :ok <- validate_sndtimeo_opt(opts) do
         {:ok,
          %{
            password: Keyword.get(opts, :password, ""),
            latency_ms: Keyword.get(opts, :latency_ms, -1),
-           socket_opts: Keyword.take(opts, [:rcvbuf, :udp_rcvbuf, :sndbuf, :udp_sndbuf])
+           socket_opts:
+             Keyword.take(opts, [:rcvbuf, :udp_rcvbuf, :sndbuf, :udp_sndbuf, :sndtimeo])
          }}
       else
         {:error, invalid_keys} when is_list(invalid_keys) ->
@@ -333,6 +337,19 @@ defmodule ExLibSRT.Server do
           {:halt, {:error, "#{key} must be a positive integer, got: #{inspect(val)}"}}
       end
     end)
+  end
+
+  defp validate_sndtimeo_opt(opts) do
+    case Keyword.fetch(opts, :sndtimeo) do
+      :error ->
+        :ok
+
+      {:ok, val} when is_integer(val) and val >= 0 ->
+        :ok
+
+      {:ok, val} ->
+        {:error, ":sndtimeo must be a non-negative integer, got: #{inspect(val)}"}
+    end
   end
 
   @spec validate_password(String.t()) :: :ok | {:error, String.t()}

--- a/scripts/listener_send_ab.sh
+++ b/scripts/listener_send_ab.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+BASELINE_REF="${BASELINE_REF:-HEAD^}"
+CANDIDATE_REF="${CANDIDATE_REF:-HEAD}"
+RUNS="${RUNS:-3}"
+DURATION_SECONDS="${DURATION_SECONDS:-60}"
+CLIENTS="${CLIENTS:-1}"
+PAYLOAD_SIZE="${PAYLOAD_SIZE:-1316}"
+LATENCY_MS="${LATENCY_MS:-120}"
+SNDTIMEO="${SNDTIMEO:--1}"
+
+WORK_ROOT="$(mktemp -d -t exlibsrt-listener-ab.XXXXXX)"
+BASELINE_WT="$WORK_ROOT/baseline"
+CANDIDATE_WT="$WORK_ROOT/candidate"
+RESULTS_TSV="$WORK_ROOT/results.tsv"
+
+cleanup() {
+  git worktree remove "$BASELINE_WT" --force >/dev/null 2>&1 || true
+  git worktree remove "$CANDIDATE_WT" --force >/dev/null 2>&1 || true
+  rm -rf "$WORK_ROOT"
+}
+trap cleanup EXIT
+
+echo "[ab] baseline_ref=$BASELINE_REF candidate_ref=$CANDIDATE_REF"
+echo "[ab] runs=$RUNS duration=${DURATION_SECONDS}s clients=$CLIENTS payload=$PAYLOAD_SIZE latency=$LATENCY_MS sndtimeo=$SNDTIMEO"
+
+git worktree add --detach "$BASELINE_WT" "$BASELINE_REF" >/dev/null
+git worktree add --detach "$CANDIDATE_WT" "$CANDIDATE_REF" >/dev/null
+
+prepare_tree() {
+  local wt="$1"
+  echo "[ab] preparing $(basename "$wt")"
+  mkdir -p "$wt/scripts"
+  cp "$ROOT_DIR/scripts/listener_send_bench.exs" "$wt/scripts/listener_send_bench.exs"
+  (
+    cd "$wt"
+    MIX_ENV=dev mix deps.get >/dev/null
+    MIX_ENV=dev mix compile >/dev/null
+  )
+}
+
+run_once() {
+  local label="$1"
+  local wt="$2"
+  local run="$3"
+  local port="$4"
+
+  local out
+  out="$(
+    cd "$wt"
+    MIX_ENV=dev mix run --no-start scripts/listener_send_bench.exs \
+      --duration "$DURATION_SECONDS" \
+      --clients "$CLIENTS" \
+      --payload "$PAYLOAD_SIZE" \
+      --latency "$LATENCY_MS" \
+      --port "$port" \
+      --sndtimeo "$SNDTIMEO" 2>&1 | rg '^RESULT ' || true
+  )"
+
+  if [[ -z "$out" ]]; then
+    echo "[ab] $label run=$run failed to produce RESULT line"
+    return 1
+  fi
+
+  echo "[ab] $label run=$run $out"
+  python3 - "$label" "$run" "$out" >> "$RESULTS_TSV" <<'PY'
+import sys
+label, run, line = sys.argv[1], sys.argv[2], sys.argv[3]
+parts = line.strip().split()
+kv = {}
+for p in parts[1:]:
+    if '=' in p:
+        k, v = p.split('=', 1)
+        kv[k] = v
+keys = [
+  'send_mbps', 'recv_mbps', 'send_errors', 'srt_mbps_send_rate', 'pkt_snd_drop', 'pkt_retrans',
+  'sent_bytes', 'recv_bytes', 'duration_s', 'clients', 'payload', 'sndtimeo'
+]
+vals = [kv.get(k, '') for k in keys]
+print('\t'.join([label, run] + vals))
+PY
+}
+
+prepare_tree "$BASELINE_WT"
+prepare_tree "$CANDIDATE_WT"
+
+echo -e "label\trun\tsend_mbps\trecv_mbps\tsend_errors\tsrt_mbps_send_rate\tpkt_snd_drop\tpkt_retrans\tsent_bytes\trecv_bytes\tduration_s\tclients\tpayload\tsndtimeo" > "$RESULTS_TSV"
+
+for i in $(seq 1 "$RUNS"); do
+  run_once baseline "$BASELINE_WT" "$i" "$((20000 + i))"
+  run_once candidate "$CANDIDATE_WT" "$i" "$((21000 + i))"
+done
+
+python3 - "$RESULTS_TSV" <<'PY'
+import sys
+from statistics import mean
+
+path = sys.argv[1]
+rows = []
+with open(path, 'r', encoding='utf-8') as f:
+    header = f.readline().strip().split('\t')
+    for line in f:
+        parts = line.strip().split('\t')
+        if len(parts) != len(header):
+            continue
+        row = dict(zip(header, parts))
+        rows.append(row)
+
+def fval(x):
+    try:
+        return float(x)
+    except Exception:
+        return 0.0
+
+for label in ('baseline', 'candidate'):
+    subset = [r for r in rows if r['label'] == label]
+    if not subset:
+        print(f'[ab] {label}: no rows')
+        continue
+    send = [fval(r['send_mbps']) for r in subset]
+    recv = [fval(r['recv_mbps']) for r in subset]
+    errs = [fval(r['send_errors']) for r in subset]
+    srt = [fval(r['srt_mbps_send_rate']) for r in subset]
+    drop = [fval(r['pkt_snd_drop']) for r in subset]
+    retr = [fval(r['pkt_retrans']) for r in subset]
+    print(f"[ab] {label}: send_avg={mean(send):.3f} recv_avg={mean(recv):.3f} srt_send_rate_avg={mean(srt):.3f} send_errors_avg={mean(errs):.1f} pkt_snd_drop_avg={mean(drop):.1f} pkt_retrans_avg={mean(retr):.1f}")
+
+base = [r for r in rows if r['label'] == 'baseline']
+cand = [r for r in rows if r['label'] == 'candidate']
+if base and cand:
+    b = mean([fval(r['send_mbps']) for r in base])
+    c = mean([fval(r['send_mbps']) for r in cand])
+    ratio = (c / b) if b > 0 else 0.0
+    print(f"[ab] delta_send_mbps={c-b:+.3f} ratio={ratio:.3f}")
+
+print(f"[ab] raw_results={path}")
+PY

--- a/scripts/listener_send_bench.exs
+++ b/scripts/listener_send_bench.exs
@@ -8,7 +8,9 @@ Mix.Task.run("app.start")
       payload: :integer,
       port: :integer,
       latency: :integer,
-      sndtimeo: :integer
+      sndtimeo: :integer,
+      batch: :integer,
+      mode: :string
     ]
   )
 
@@ -18,9 +20,19 @@ payload_size = Keyword.get(opts, :payload, 1316)
 port = Keyword.get(opts, :port, 19_000 + :rand.uniform(2000))
 latency_ms = Keyword.get(opts, :latency, 120)
 sndtimeo = Keyword.get(opts, :sndtimeo, -1)
+mode = Keyword.get(opts, :mode, "single")
+batch_size = Keyword.get(opts, :batch, 8)
 
 if payload_size <= 0 or payload_size > 1316 do
   raise "payload must be in 1..1316"
+end
+
+if mode not in ["single", "many"] do
+  raise "mode must be single|many"
+end
+
+if batch_size <= 0 or batch_size > 32 do
+  raise "batch must be in 1..32"
 end
 
 parent = self()
@@ -92,10 +104,11 @@ for _ <- 1..clients do
     {:srt_server_connect_request, _address, _stream_id} ->
       :ok = ExLibSRT.Server.accept_awaiting_connect_request(server)
 
-    other ->
-      IO.puts("[bench] ignoring message while awaiting connect request: #{inspect(other)}")
-      :timer.sleep(10)
-      send(self(), other)
+    {:srt_server_send_telemetry, _q, _d, _r, _bps} ->
+      :ok
+
+    _other ->
+      :ok
   after
     10_000 -> raise "timed out waiting for connect request"
   end
@@ -106,6 +119,9 @@ conn_ids =
     receive do
       {:srt_server_conn, conn_id, _stream_id} ->
         {:cont, [conn_id | acc]}
+
+      {:srt_server_send_telemetry, _q, _d, _r, _bps} ->
+        {:cont, acc}
 
       _other ->
         {:cont, acc}
@@ -120,8 +136,8 @@ if length(conn_ids) != clients do
 end
 
 payload = :binary.copy(<<0>>, payload_size)
+batch_payloads = List.duplicate(payload, batch_size)
 deadline_ms = System.monotonic_time(:millisecond) + duration_s * 1000
-
 sender_parent = self()
 
 for conn_id <- conn_ids do
@@ -132,9 +148,17 @@ for conn_id <- conn_ids do
       if now >= deadline_ms do
         send(sender_parent, {:sender_done, self()})
       else
-        case ExLibSRT.Server.send_data(conn_id, payload, server) do
+        result =
+          if mode == "many" do
+            ExLibSRT.Server.send_data_many(conn_id, batch_payloads, server)
+          else
+            ExLibSRT.Server.send_data(conn_id, payload, server)
+          end
+
+        case result do
           :ok ->
-            :atomics.add_get(send_bytes, 1, payload_size)
+            sent_now = if mode == "many", do: payload_size * batch_size, else: payload_size
+            :atomics.add_get(send_bytes, 1, sent_now)
 
           {:error, _reason} ->
             :atomics.add_get(send_errors, 1, 1)
@@ -152,7 +176,7 @@ for _ <- 1..clients do
   receive do
     {:sender_done, _pid} -> :ok
   after
-    duration_s * 2000 -> raise "timed out waiting for sender"
+    duration_s * 3000 -> raise "timed out waiting for sender"
   end
 end
 
@@ -174,6 +198,19 @@ for _ <- receivers do
   end
 end
 
+telemetry_samples =
+  Stream.repeatedly(fn ->
+    receive do
+      {:srt_server_send_telemetry, queue_depth, enqueue_drops, send_retries, drain_rate_bps} ->
+        {:ok, {queue_depth, enqueue_drops, send_retries, drain_rate_bps}}
+    after
+      0 ->
+        :done
+    end
+  end)
+  |> Enum.take_while(&(&1 != :done))
+  |> Enum.map(fn {:ok, sample} -> sample end)
+
 ExLibSRT.Server.stop(server)
 
 sent = :atomics.get(send_bytes, 1)
@@ -187,18 +224,40 @@ sum = fn fun -> Enum.reduce(stats, 0, fn st, acc -> acc + fun.(st) end) end
 
 pkt_snd_drop = sum.(fn st -> st.pktSndDrop end)
 pkt_retrans = sum.(fn st -> st.pktRetrans end)
+
 mbps_send_rate_avg =
   case stats do
     [] -> 0.0
     list -> Enum.reduce(list, 0.0, fn st, acc -> acc + st.mbpsSendRate end) / length(list)
   end
 
+{queue_depth_max, enqueue_drops_last, send_retries_last, drain_rate_bps_avg} =
+  case telemetry_samples do
+    [] ->
+      {0, 0, 0, 0}
+
+    samples ->
+      qmax = samples |> Enum.map(&elem(&1, 0)) |> Enum.max()
+      dlast = samples |> List.last() |> elem(1)
+      rlast = samples |> List.last() |> elem(2)
+      bavg =
+        samples
+        |> Enum.map(&elem(&1, 3))
+        |> Enum.sum()
+        |> Kernel./(length(samples))
+        |> round()
+
+      {qmax, dlast, rlast, bavg}
+  end
+
 IO.puts(
   "RESULT " <>
-    "duration_s=#{duration_s} clients=#{clients} payload=#{payload_size} sndtimeo=#{sndtimeo} " <>
+    "mode=#{mode} batch=#{batch_size} duration_s=#{duration_s} clients=#{clients} payload=#{payload_size} sndtimeo=#{sndtimeo} " <>
     "sent_bytes=#{sent} recv_bytes=#{recv} send_errors=#{errors} " <>
     "send_mbps=#{:erlang.float_to_binary(send_mbps, decimals: 3)} " <>
     "recv_mbps=#{:erlang.float_to_binary(recv_mbps, decimals: 3)} " <>
     "srt_mbps_send_rate=#{:erlang.float_to_binary(mbps_send_rate_avg, decimals: 3)} " <>
-    "pkt_snd_drop=#{pkt_snd_drop} pkt_retrans=#{pkt_retrans}"
+    "pkt_snd_drop=#{pkt_snd_drop} pkt_retrans=#{pkt_retrans} " <>
+    "queue_depth_max=#{queue_depth_max} enqueue_drops=#{enqueue_drops_last} " <>
+    "send_retries=#{send_retries_last} drain_rate_bps_avg=#{drain_rate_bps_avg}"
 )

--- a/scripts/listener_send_bench.exs
+++ b/scripts/listener_send_bench.exs
@@ -1,0 +1,204 @@
+Mix.Task.run("app.start")
+
+{opts, _argv, _invalid} =
+  OptionParser.parse(System.argv(),
+    strict: [
+      duration: :integer,
+      clients: :integer,
+      payload: :integer,
+      port: :integer,
+      latency: :integer,
+      sndtimeo: :integer
+    ]
+  )
+
+duration_s = Keyword.get(opts, :duration, 60)
+clients = Keyword.get(opts, :clients, 1)
+payload_size = Keyword.get(opts, :payload, 1316)
+port = Keyword.get(opts, :port, 19_000 + :rand.uniform(2000))
+latency_ms = Keyword.get(opts, :latency, 120)
+sndtimeo = Keyword.get(opts, :sndtimeo, -1)
+
+if payload_size <= 0 or payload_size > 1316 do
+  raise "payload must be in 1..1316"
+end
+
+parent = self()
+recv_bytes = :atomics.new(1, [])
+send_bytes = :atomics.new(1, [])
+send_errors = :atomics.new(1, [])
+
+defmodule BenchReceiver do
+  def start(parent, recv_bytes, port, idx, latency_ms) do
+    spawn_link(fn ->
+      stream_id = "bench-#{idx}"
+
+      {:ok, client} =
+        ExLibSRT.Client.start_link("127.0.0.1", port, stream_id,
+          mode: :receiver,
+          latency_ms: latency_ms
+        )
+
+      send(parent, {:receiver_ready, self()})
+      loop(client, recv_bytes)
+    end)
+  end
+
+  defp loop(client, recv_bytes) do
+    receive do
+      {:bench_stop, from} ->
+        ExLibSRT.Client.stop(client)
+        send(from, {:bench_stopped, self()})
+
+      {:srt_data, _conn_id, payload} ->
+        :atomics.add_get(recv_bytes, 1, byte_size(payload))
+        loop(client, recv_bytes)
+
+      :srt_client_connected ->
+        loop(client, recv_bytes)
+
+      :srt_client_disconnected ->
+        loop(client, recv_bytes)
+
+      {:srt_client_error, _reason} ->
+        loop(client, recv_bytes)
+
+      _other ->
+        loop(client, recv_bytes)
+    end
+  end
+end
+
+server_opts = [latency_ms: latency_ms, udp_rcvbuf: 67_108_864]
+server_opts = if sndtimeo >= 0, do: Keyword.put(server_opts, :sndtimeo, sndtimeo), else: server_opts
+
+{:ok, server} = ExLibSRT.Server.start_link("127.0.0.1", port, server_opts)
+
+receivers =
+  for idx <- 1..clients do
+    BenchReceiver.start(parent, recv_bytes, port, idx, latency_ms)
+  end
+
+for _ <- 1..clients do
+  receive do
+    {:receiver_ready, _pid} -> :ok
+  after
+    5_000 -> raise "timed out waiting for receiver startup"
+  end
+end
+
+for _ <- 1..clients do
+  receive do
+    {:srt_server_connect_request, _address, _stream_id} ->
+      :ok = ExLibSRT.Server.accept_awaiting_connect_request(server)
+
+    other ->
+      IO.puts("[bench] ignoring message while awaiting connect request: #{inspect(other)}")
+      :timer.sleep(10)
+      send(self(), other)
+  after
+    10_000 -> raise "timed out waiting for connect request"
+  end
+end
+
+conn_ids =
+  Enum.reduce_while(1..clients, [], fn _, acc ->
+    receive do
+      {:srt_server_conn, conn_id, _stream_id} ->
+        {:cont, [conn_id | acc]}
+
+      _other ->
+        {:cont, acc}
+    after
+      10_000 ->
+        {:halt, acc}
+    end
+  end)
+
+if length(conn_ids) != clients do
+  raise "expected #{clients} connected clients, got #{length(conn_ids)}"
+end
+
+payload = :binary.copy(<<0>>, payload_size)
+deadline_ms = System.monotonic_time(:millisecond) + duration_s * 1000
+
+sender_parent = self()
+
+for conn_id <- conn_ids do
+  spawn_link(fn ->
+    send_loop = fn send_loop ->
+      now = System.monotonic_time(:millisecond)
+
+      if now >= deadline_ms do
+        send(sender_parent, {:sender_done, self()})
+      else
+        case ExLibSRT.Server.send_data(conn_id, payload, server) do
+          :ok ->
+            :atomics.add_get(send_bytes, 1, payload_size)
+
+          {:error, _reason} ->
+            :atomics.add_get(send_errors, 1, 1)
+        end
+
+        send_loop.(send_loop)
+      end
+    end
+
+    send_loop.(send_loop)
+  end)
+end
+
+for _ <- 1..clients do
+  receive do
+    {:sender_done, _pid} -> :ok
+  after
+    duration_s * 2000 -> raise "timed out waiting for sender"
+  end
+end
+
+stats =
+  conn_ids
+  |> Enum.map(&ExLibSRT.Server.read_socket_stats(&1, server))
+  |> Enum.filter(&match?({:ok, _}, &1))
+  |> Enum.map(fn {:ok, st} -> st end)
+
+for pid <- receivers do
+  send(pid, {:bench_stop, self()})
+end
+
+for _ <- receivers do
+  receive do
+    {:bench_stopped, _pid} -> :ok
+  after
+    5_000 -> :ok
+  end
+end
+
+ExLibSRT.Server.stop(server)
+
+sent = :atomics.get(send_bytes, 1)
+recv = :atomics.get(recv_bytes, 1)
+errors = :atomics.get(send_errors, 1)
+
+send_mbps = sent * 8 / 1_000_000 / duration_s
+recv_mbps = recv * 8 / 1_000_000 / duration_s
+
+sum = fn fun -> Enum.reduce(stats, 0, fn st, acc -> acc + fun.(st) end) end
+
+pkt_snd_drop = sum.(fn st -> st.pktSndDrop end)
+pkt_retrans = sum.(fn st -> st.pktRetrans end)
+mbps_send_rate_avg =
+  case stats do
+    [] -> 0.0
+    list -> Enum.reduce(list, 0.0, fn st, acc -> acc + st.mbpsSendRate end) / length(list)
+  end
+
+IO.puts(
+  "RESULT " <>
+    "duration_s=#{duration_s} clients=#{clients} payload=#{payload_size} sndtimeo=#{sndtimeo} " <>
+    "sent_bytes=#{sent} recv_bytes=#{recv} send_errors=#{errors} " <>
+    "send_mbps=#{:erlang.float_to_binary(send_mbps, decimals: 3)} " <>
+    "recv_mbps=#{:erlang.float_to_binary(recv_mbps, decimals: 3)} " <>
+    "srt_mbps_send_rate=#{:erlang.float_to_binary(mbps_send_rate_avg, decimals: 3)} " <>
+    "pkt_snd_drop=#{pkt_snd_drop} pkt_retrans=#{pkt_retrans}"
+)

--- a/test/ex_libsrt/client_server_coop_test.exs
+++ b/test/ex_libsrt/client_server_coop_test.exs
@@ -41,6 +41,61 @@ defmodule ExLibSRT.ClientServerCoopTest do
     assert_receive :stopped, 8000
   end
 
+  test "receive data in caller mode when client is started as receiver", ctx do
+    parent = self()
+
+    {:ok, server_task} =
+      Task.start(fn ->
+        assert {:ok, server} = Server.start("127.0.0.1", ctx.srt_port)
+
+        send(parent, :server_running)
+
+        assert_receive {:srt_server_connect_request, _address, "some_stream_id"}, 1_000
+        :ok = Server.accept_awaiting_connect_request(server)
+
+        assert_receive {:srt_server_conn, conn_id, _stream_id}, 1_000
+        send(parent, {:server_connected, server, conn_id})
+
+        receive do
+          :stop_server -> :ok
+        after
+          15_000 -> :ok
+        end
+
+        Server.stop(server)
+        send(parent, :server_stopped)
+      end)
+
+    assert_receive :server_running, 1_000
+
+    assert {:ok, client_ref} =
+             ExLibSRT.Native.start_client_with_mode(
+               "127.0.0.1",
+               ctx.srt_port,
+               "some_stream_id",
+               "",
+               -1,
+               0
+             )
+
+    on_exit(fn ->
+      _ = ExLibSRT.Native.stop_client(client_ref)
+      :ok
+    end)
+
+    assert_receive :srt_client_connected, 2_000
+    assert_receive {:server_connected, server, conn_id}, 2_000
+
+    assert :ok = Server.send_data(conn_id, "hello", server)
+    assert_receive {:srt_data, 0, "hello"}, 5_000
+
+    assert {:error, "Client is not in sender mode"} =
+             ExLibSRT.Native.send_client_data("hello", client_ref)
+
+    send(server_task, :stop_server)
+    assert_receive :server_stopped, 2_000
+  end
+
   test "reject client connection", ctx do
     parent = self()
 

--- a/test/ex_libsrt/client_test.exs
+++ b/test/ex_libsrt/client_test.exs
@@ -130,6 +130,28 @@ defmodule ExLibSRT.ClientTest do
     end
   end
 
+  describe "client options validation" do
+    test "rejects invalid mode option" do
+      assert {:error, "Invalid client mode :invalid. Expected :sender or :receiver.", 0} =
+               Client.start_link("127.0.0.1", 8080, "stream1", mode: :invalid)
+    end
+
+    test "rejects unsupported options" do
+      assert {:error, "Unsupported client options: :unknown", 0} =
+               Client.start_link("127.0.0.1", 8080, "stream1", unknown: true)
+    end
+
+    test "rejects non-integer latency option" do
+      assert {:error, "Latency must be an integer, got: \"100\"", 0} =
+               Client.start_link("127.0.0.1", 8080, "stream1", latency_ms: "100")
+    end
+
+    test "rejects non-keyword options list" do
+      assert {:error, "Client options must be a keyword list", 0} =
+               Client.start_link("127.0.0.1", 8080, "stream1", ~c"not-keyword")
+    end
+  end
+
   defp prepare_streaming(_ctx) do
     udp_port = Enum.random(10_000..20_000)
     srt_port = Enum.random(10_000..20_000)

--- a/test/ex_libsrt/server_test.exs
+++ b/test/ex_libsrt/server_test.exs
@@ -61,16 +61,16 @@ defmodule ExLibSRT.ServerTest do
 
       assert_receive {:srt_server_conn, conn_id, _stream_id}, 1_000
 
+      expected = Enum.map_join(1..10, fn i -> "Hello world! (#{i})" end)
+
       for i <- 1..10 do
         :ok = Transmit.send_payload(stream, "Hello world! (#{i})")
       end
 
       :ok = Transmit.close_stream(stream)
 
-      for i <- 1..10 do
-        assert_receive {:srt_data, ^conn_id, payload}, 500
-        assert payload == "Hello world! (#{i})"
-      end
+      received = collect_srt_data(conn_id, byte_size(expected), 2_000)
+      assert received == expected
 
       Transmit.stop_proxy(proxy)
     end
@@ -187,12 +187,14 @@ defmodule ExLibSRT.ServerTest do
       on_exit(fn -> close_stream_safe(stream) end)
 
       payload = :crypto.strong_rand_bytes(100)
+      expected = String.duplicate(payload, 10)
 
       for _i <- 1..10 do
         :ok = Transmit.send_payload(stream, payload)
-
-        assert_receive {:srt_data, ^conn_id, ^payload}, 1_000
       end
+
+      received = collect_srt_data(conn_id, byte_size(expected), 2_000)
+      assert received == expected
 
       assert {:ok, stats} = Server.read_socket_stats(conn_id, ctx.server)
 
@@ -256,16 +258,16 @@ defmodule ExLibSRT.ServerTest do
       refute_receive {:srt_server_conn, _conn_id, _stream_id}, 1_000
       assert_receive {:srt_handler_connected, _conn_id, _stream_id}, 1_000
 
+      expected = Enum.map_join(1..10, fn i -> "Hello world! (#{i})" end)
+
       for i <- 1..10 do
         :ok = Transmit.send_payload(stream, "Hello world! (#{i})")
       end
 
       :ok = Transmit.close_stream(stream)
 
-      for i <- 1..10 do
-        assert_receive {:srt_handler_data, payload}, 500
-        assert payload == "Hello world! (#{i})"
-      end
+      received = collect_handler_data(byte_size(expected), 2_000)
+      assert received == expected
 
       Transmit.stop_proxy(proxy)
 
@@ -336,6 +338,51 @@ defmodule ExLibSRT.ServerTest do
   defp close_stream_safe(socket) do
     if is_port(socket) and :erlang.port_info(socket) != nil do
       :ok = Transmit.close_stream(socket)
+    end
+  end
+
+  # Collect coalesced {:srt_data, conn_id, payload} messages until we have
+  # at least `expected_bytes` bytes or `timeout_ms` elapses.
+  defp collect_srt_data(conn_id, expected_bytes, timeout_ms) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_collect_srt_data(conn_id, [], 0, expected_bytes, deadline)
+  end
+
+  defp do_collect_srt_data(_conn_id, acc, collected, expected, _deadline) when collected >= expected do
+    IO.iodata_to_binary(Enum.reverse(acc))
+  end
+
+  defp do_collect_srt_data(conn_id, acc, collected, expected, deadline) do
+    remaining = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      {:srt_data, ^conn_id, payload} ->
+        do_collect_srt_data(conn_id, [payload | acc], collected + byte_size(payload), expected, deadline)
+    after
+      remaining ->
+        flunk("Timed out waiting for srt_data: got #{collected}/#{expected} bytes")
+    end
+  end
+
+  # Same for {:srt_handler_data, payload} messages from Connection.Handler.
+  defp collect_handler_data(expected_bytes, timeout_ms) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_collect_handler_data([], 0, expected_bytes, deadline)
+  end
+
+  defp do_collect_handler_data(acc, collected, expected, _deadline) when collected >= expected do
+    IO.iodata_to_binary(Enum.reverse(acc))
+  end
+
+  defp do_collect_handler_data(acc, collected, expected, deadline) do
+    remaining = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      {:srt_handler_data, payload} ->
+        do_collect_handler_data([payload | acc], collected + byte_size(payload), expected, deadline)
+    after
+      remaining ->
+        flunk("Timed out waiting for srt_handler_data: got #{collected}/#{expected} bytes")
     end
   end
 end

--- a/test/support/srt_live_transmit.ex
+++ b/test/support/srt_live_transmit.ex
@@ -58,6 +58,31 @@ defmodule ExLibSRT.SRTLiveTransmit do
     port
   end
 
+  @spec start_caller_receiving_proxy(non_neg_integer(), non_neg_integer(), binary()) ::
+          receiving_proxy()
+  def start_caller_receiving_proxy(srt_port, udp_port, stream_id \\ "") do
+    auth =
+      if stream_id != "" do
+        "?streamid=#{stream_id}"
+      else
+        ""
+      end
+
+    args = [
+      :binary,
+      {:args,
+       [
+         "-q",
+         "-loglevel:fatal",
+         "-autoreconnect:no",
+         "srt://127.0.0.1:#{srt_port}" <> auth,
+         "udp://127.0.0.1:#{udp_port}"
+       ]}
+    ]
+
+    Port.open({:spawn_executable, find_executable("srt-live-transmit")}, args)
+  end
+
   defp find_executable(executable_name) do
     case System.find_executable(executable_name) do
       nil ->


### PR DESCRIPTION
`ex_libsrt` was missing two capabilities needed by downstream caller-side ingest workflows:

1. Server could accept/receive, but had no API to send payloads back through an active connection.
2. Client startup was effectively sender-only in public usage, so caller-mode ingest could connect but not receive media.

These changes enable caller-side ingest scenarios that require receiving data through the native client API.

I tested the setup in both modes and can confirm that it is working! Let me know if there are any changes you'd like me to apply. As always, I'd like to drop the fork ASAP.

Follows the description of the changes made by my clanker. I guess the srt-live-transmit sanity check might be unwanted, but I wanted to include it anyway, maybe you like the approach.

---

## Changes

### 1) Server-side send support

- Native API: `ExLibSRT.Native.send_server_data(conn_id, payload, server_ref)`
- Public API: `ExLibSRT.Server.send_data(connection_id, payload, server_pid)`

Behavior:
- validates active server and connection
- sends via `srt_sendmsg`
- returns `:ok | {:error, reason}`
- enforces max payload size (`1316`) in `Server.send_data/3`

### 2) Receiver-mode client data path

- client mode controls `SRTO_SENDER`
- receiver mode enables `SRT_EPOLL_IN`
- receiver mode reads with `srt_recv`
- emits `{:srt_data, 0, payload}`
- `send_client_data/2` returns `{:error, "Client is not in sender mode"}` in receiver mode

### 3) Public API shape (developer-facing)

- public mode is atom-based: `:sender | :receiver`
- public entrypoints:
  - `ExLibSRT.Native.start_client/5` (default sender)
  - `ExLibSRT.Native.start_client/6` (explicit mode)
  - `ExLibSRT.Client.start/4` and `start_link/4` with options (`mode`, `password`, `latency_ms`)
- integer flag is internal-only via native entrypoint `start_client_native/6`
- `start_client_with_mode/6` is not exposed publicly

## Compatibility

- sender remains the default
- existing positional `Client.start/...` and `start_link/...` calls still work
- no expected break for published users

## Tests

- server send path tests (`Server.send_data/3`, payload size)
- coop test verifies receiver-mode client receives server payload
- receiver-mode send rejection verified
- options validation tests added
- full suite passes: `mix test`

## Recommended version bump

**Minor** (`0.1.6 -> 0.2.0`).

Reason: this PR adds new public capabilities/API surface while keeping published behavior backward compatible.
