### PR TITLE
Throw runtime error instead of a pointer. Bump to v0.1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The package exposes a server and a client module to interact with SRT streams.
 ```elixir
 def deps do
   [
-    {:ex_libsrt, "~> 0.1.6"}
+    {:ex_libsrt, "~> 0.1.7"}
   ]
 end
 ```

--- a/c_src/ex_libsrt/server/server.cpp
+++ b/c_src/ex_libsrt/server/server.cpp
@@ -285,7 +285,7 @@ void Server::AcceptConnection() {
 
   int socket = srt_accept(srt_sock, (struct sockaddr*)&their_addr, &addr_len);
   if (socket == -1) {
-    throw new std::runtime_error("Failed to accept new socket");
+    throw std::runtime_error("Failed to accept new socket");
   }
 
   char raw_streamid[512] = {0};

--- a/c_src/ex_libsrt/srt_nif.cpp
+++ b/c_src/ex_libsrt/srt_nif.cpp
@@ -136,7 +136,7 @@ UNIFEX_TERM start_server(UnifexEnv* env,
   try {
     state->env = unifex_alloc_env(env);
     if (!unifex_self(env, &state->owner)) {
-      throw new std::runtime_error("failed to create native state");
+      throw std::runtime_error("failed to create native state");
     };
 
     state->server = std::make_unique<Server>();
@@ -283,7 +283,7 @@ start_client(UnifexEnv* env,
   try {
     state->env = unifex_alloc_env(env);
     if (!unifex_self(env, &state->owner)) {
-      throw new std::runtime_error("failed to create native state");
+      throw std::runtime_error("failed to create native state");
     };
 
     state->client = std::make_unique<Client>(10, 200);

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExLibSRT.MixProject do
   use Mix.Project
 
-  @version "0.1.6"
+  @version "0.1.7"
   @github_url "https://github.com/membraneframework/ex_libsrt"
 
   def project do


### PR DESCRIPTION
This PR:
* makes sure the thrown exception is of a proper type (we used to throw `std::exception *` instead of `std::exception` which could cause memory leaks)
* bumps version to v0.1.7