### PR TITLE
Set stream ids whitelist a priori

### DIFF
--- a/MIGRATION_v0_2.md
+++ b/MIGRATION_v0_2.md
@@ -1,0 +1,61 @@
+# Migration Guide for release v0.2.0
+
+v0.2.0 introduces a new API for starting server and handling connections.
+Below there is a description of changes that need to be implemented while migrating
+from v0.1.x.
+
+## start() and start_link() signatures
+[`ExLibSRT.Server.start/3`](https://hexdocs.pm/ex_libsrt/0.2.0/ExLibSRT.Server.html#start/3) and [`start_link/3`](https://hexdocs.pm/ex_libsrt/0.2.0/ExLibSRT.Server.html#start_link/3) signatures have changed.
+`password` and `latency_ms` options now need to be provided as a keyword list elements.
+Furthermore, a new option: `:accept_mode` was added - more information in [Connection handling](#connection-handling) section.
+
+```diff
+- {:ok, server} = ExLibSRT.Server.start("0.0.0.0", 12_000, "some_password", 1000)
++ {:ok, server} = ExLibSRT.Server.start("0.0.0.0", 12_000, accept_mode: :accept_all, password: "some_password", latency_ms: 1000)
+```
+
+## Connection handling
+
+The `{:srt_server_conn, <connection ID>, <stream ID>}` message is sent to the server's "owner" process (which can be specified by the `:owner` option of [`ExLibSRT.Server.start/3`](https://hexdocs.pm/ex_libsrt/0.2.0/ExLibSRT.Server.html#start/3) and [`ExLibSRT.Server.start_link/3`](https://hexdocs.pm/ex_libsrt/0.2.0/ExLibSRT.Server.html#start_link/3) functions).
+The old functions `ExLibSRT.Server.accept_awaiting_connect_request/1`, `ExLibSRT.Server.accept_awaiting_connect_request_with_handler/2` and `ExLibSRT.Server.reject_awaiting_connect_request/1` were removed since the connection
+is now either always accepted (with `accept_mode: :accept_all`) or accepted or rejected based on the `stream_id` (with `accept_mode: :whitelist` and `accept_mode: {:whitelist, <initial_whitelist>}`).
+After acceptance, the connection needs to be bound with a process or a handler module handling incoming data, which is done with [`ExLibSRT.Server.bind_with_process/3`](https://hexdocs.pm/ex_libsrt/0.2.0/ExLibSRT.Server.html#bind_with_process/3) and [`ExLibSRT.Server.bind_with_handler/3`](https://hexdocs.pm/ex_libsrt/0.2.0/ExLibSRT.Server.html#bind_with_handler/3) functions.
+
+```diff
+- receive do
+-   {:srt_server_connect_request, _addr, stream_id} ->
+-     {:ok, _conn} = ExLibSRT.Server.accept_awaiting_connect_request(stream_id, server, receiver_pid)
+- end
+
++ receive do
++   {:srt_server_conn, conn_id, _stream_id} ->
++     {:ok, _conn} = ExLibSRT.Server.bind_with_handler(%MyHandler{}, server, conn_id)
++ end
+```
+
+## ConnectionHandler callbacks changes
+
+The `handle_connected/3` callback in [`ExLibSRT.Connection.Handler`](https://hexdocs.pm/ex_libsrt/0.2.0/ExLibSRT.Connection.Handler.html) was removed since now the connection handler is bound to an already connected client connection.
+
+```diff
+  @impl true
+- def handle_connected(conn_id, stream_id, state) do
+-   {:ok, Map.put(state, :conn_id, conn_id)}
+- end
+-
+  @impl true
+  def handle_data(data, state) do
+    ...
+  end
+```
+
+## New: Rejection handling
+
+The owner process of the server now gets notified when connection is rejected (which might happen only in the whitelist mode).
+
+```diff
++ receive do
++   {:srt_server_rejected_client, stream_id} ->
++     Logger.warning("Rejected: #{stream_id}")
++ end
+```

--- a/MIGRATION_v0_2.md
+++ b/MIGRATION_v0_2.md
@@ -5,7 +5,7 @@ Below there is a description of changes that need to be implemented while migrat
 from v0.1.x.
 
 ## start() and start_link() signatures
-[`ExLibSRT.Server.start/3`](https://hexdocs.pm/ex_libsrt/0.2.0/ExLibSRT.Server.html#start/3) and [`start_link/3`](https://hexdocs.pm/ex_libsrt/0.2.0/ExLibSRT.Server.html#start_link/3) signatures have changed.
+`ExLibSRT.Server.start/3` and `start_link/3` signatures have changed.
 `password` and `latency_ms` options now need to be provided as a keyword list elements.
 Furthermore, a new option: `:accept_mode` was added - more information in [Connection handling](#connection-handling) section.
 
@@ -16,10 +16,10 @@ Furthermore, a new option: `:accept_mode` was added - more information in [Conne
 
 ## Connection handling
 
-The `{:srt_server_conn, <connection ID>, <stream ID>}` message is sent to the server's "owner" process (which can be specified by the `:owner` option of [`ExLibSRT.Server.start/3`](https://hexdocs.pm/ex_libsrt/0.2.0/ExLibSRT.Server.html#start/3) and [`ExLibSRT.Server.start_link/3`](https://hexdocs.pm/ex_libsrt/0.2.0/ExLibSRT.Server.html#start_link/3) functions).
-The old functions `ExLibSRT.Server.accept_awaiting_connect_request/1`, `ExLibSRT.Server.accept_awaiting_connect_request_with_handler/2` and `ExLibSRT.Server.reject_awaiting_connect_request/1` were removed since the connection
+The `{:srt_server_conn, <connection ID>, <stream ID>}` message is sent to the server's "owner" process (which can be specified by the `:owner` option of `ExLibSRT.Server.start/3` and `ExLibSRT.Server.start_link/3` functions).
+The old functions `ExLibSRT.Server.accept_awaiting_connect_request`, `ExLibSRT.Server.accept_awaiting_connect_request_with_handler` and `ExLibSRT.Server.reject_awaiting_connect_request` were removed since the connection
 is now either always accepted (with `accept_mode: :accept_all`) or accepted or rejected based on the `stream_id` (with `accept_mode: :whitelist` and `accept_mode: {:whitelist, <initial_whitelist>}`).
-After acceptance, the connection needs to be bound with a process or a handler module handling incoming data, which is done with [`ExLibSRT.Server.bind_with_process/3`](https://hexdocs.pm/ex_libsrt/0.2.0/ExLibSRT.Server.html#bind_with_process/3) and [`ExLibSRT.Server.bind_with_handler/3`](https://hexdocs.pm/ex_libsrt/0.2.0/ExLibSRT.Server.html#bind_with_handler/3) functions.
+After acceptance, the connection needs to be bound with a process or a handler module handling incoming data, which is done with `ExLibSRT.Server.bind_with_process/3` and `ExLibSRT.Server.bind_with_handler/3` functions.
 
 ```diff
 - receive do
@@ -35,7 +35,7 @@ After acceptance, the connection needs to be bound with a process or a handler m
 
 ## ConnectionHandler callbacks changes
 
-The `handle_connected/3` callback in [`ExLibSRT.Connection.Handler`](https://hexdocs.pm/ex_libsrt/0.2.0/ExLibSRT.Connection.Handler.html) was removed since now the connection handler is bound to an already connected client connection.
+The `handle_connected/3` callback in `ExLibSRT.Connection.Handler` was removed since now the connection handler is bound to an already connected client connection.
 
 ```diff
   @impl true

--- a/README.md
+++ b/README.md
@@ -13,10 +13,14 @@ The package exposes a server and a client module to interact with SRT streams.
 ```elixir
 def deps do
   [
-    {:ex_libsrt, "~> 0.1.7"}
+    {:ex_libsrt, "~> 0.2.0"}
   ]
 end
 ```
+
+## Migration Guide
+
+If you are upgrading from version 0.1.x to 0.2.0, please refer to the [Migration Guide](MIGRATION_v0_2.md) for detailed information about breaking changes and how to update your code.
 
 ## Example usage
 

--- a/c_src/ex_libsrt/server/server.cpp
+++ b/c_src/ex_libsrt/server/server.cpp
@@ -1,26 +1,27 @@
 #include "server.h"
 
-#include <chrono>
 #include <cstring>
-#include <exception>
 #include <string>
-#include <vector>
 #include <unifex/unifex.h>
+#include <unordered_set>
+#include <vector>
 
 void Server::Run(const std::string& address,
                  int port,
                  const std::string& password,
-                 int latency_ms) {
+                 int latency_ms,
+                 std::unordered_set<std::string> ids_whitelist) {
   this->password = password;
   this->latency_ms = latency_ms;
+  this->stream_ids_whitelist = std::move(ids_whitelist);
 
   struct sockaddr_storage ss;
   socklen_t ss_len;
   int af;
   memset(&ss, 0, sizeof(ss));
 
-  struct sockaddr_in6 *sa6 = reinterpret_cast<struct sockaddr_in6*>(&ss);
-  struct sockaddr_in  *sa4 = reinterpret_cast<struct sockaddr_in*>(&ss);
+  struct sockaddr_in6* sa6 = reinterpret_cast<struct sockaddr_in6*>(&ss);
+  struct sockaddr_in* sa4 = reinterpret_cast<struct sockaddr_in*>(&ss);
 
   if (inet_pton(AF_INET6, address.c_str(), &sa6->sin6_addr) == 1) {
     sa6->sin6_family = AF_INET6;
@@ -45,20 +46,24 @@ void Server::Run(const std::string& address,
   int no = 0;
 
   if (af == AF_INET6) {
-    if (srt_setsockflag(srt_sock, SRTO_IPV6ONLY, &yes, sizeof yes) == SRT_ERROR) {
-        throw std::runtime_error(std::string(srt_getlasterror_str()));
+    if (srt_setsockflag(srt_sock, SRTO_IPV6ONLY, &yes, sizeof yes) ==
+        SRT_ERROR) {
+      throw std::runtime_error(std::string(srt_getlasterror_str()));
     }
   }
 
   srt_setsockflag(srt_sock, SRTO_RCVSYN, &no, sizeof yes);
   srt_setsockflag(srt_sock, SRTO_STREAMID, &yes, sizeof yes);
   if (latency_ms >= 0) {
-    if (srt_setsockflag(srt_sock, SRTO_LATENCY, &latency_ms, sizeof latency_ms) == SRT_ERROR) {
+    if (srt_setsockflag(
+            srt_sock, SRTO_LATENCY, &latency_ms, sizeof latency_ms) ==
+        SRT_ERROR) {
       throw std::runtime_error(std::string(srt_getlasterror_str()));
     }
   }
 
-  srt_bind_sock = srt_bind(srt_sock, reinterpret_cast<struct sockaddr*>(&ss), ss_len);
+  srt_bind_sock =
+      srt_bind(srt_sock, reinterpret_cast<struct sockaddr*>(&ss), ss_len);
   if (srt_bind_sock == SRT_ERROR) {
     throw std::runtime_error(std::string(srt_getlasterror_str()));
   }
@@ -84,7 +89,8 @@ void Server::Run(const std::string& address,
   epoll_loop = std::thread(&Server::RunEpoll, this);
 }
 
-std::unique_ptr<SrtSocketStats> Server::ReadSocketStats(int socket, bool clear_intervals) {
+std::unique_ptr<SrtSocketStats> Server::ReadSocketStats(int socket,
+                                                        bool clear_intervals) {
   if (active_sockets.find(socket) != std::end(active_sockets)) {
     return readSrtSocketStats(socket, clear_intervals);
   }
@@ -103,7 +109,8 @@ void Server::Stop() {
 }
 
 void Server::CloseConnection(int connection_id) {
-  if (auto connection = active_sockets.find(connection_id); connection != std::end(active_sockets)) {
+  if (auto connection = active_sockets.find(connection_id);
+      connection != std::end(active_sockets)) {
     srt_epoll_remove_usock(epoll, connection_id);
     srt_close(connection_id);
 
@@ -113,15 +120,17 @@ void Server::CloseConnection(int connection_id) {
 }
 
 void Server::RunEpoll() {
-  // Setting this one prevents spamming with "no sockets to check, this would deadlock" logs during closing
-  // of the system, when there are no sockets in the epoll anymore
+  // Setting this one prevents spamming with "no sockets to check, this would
+  // deadlock" logs during closing of the system, when there are no sockets in
+  // the epoll anymore
   srt_epoll_set(epoll, SRT_EPOLL_ENABLE_EMPTY);
 
   int sockets_len = 100;
   std::vector<SrtSocket> sockets(static_cast<size_t>(sockets_len));
 
   int broken_sockets_len = 100;
-  std::vector<SrtSocket> broken_sockets(static_cast<size_t>(broken_sockets_len));
+  std::vector<SrtSocket> broken_sockets(
+      static_cast<size_t>(broken_sockets_len));
 
   while (running.load()) {
     sockets_len = 100;
@@ -149,13 +158,15 @@ void Server::RunEpoll() {
       auto socket_state = srt_getsockstate(sockets[i]);
 
       if (socket_state == SRTS_LISTENING) {
-        AcceptConnection();
+        // do nothing
       } else if (socket_state == SRTS_BROKEN || socket_state == SRTS_CLOSED) {
         DisconnectSocket(sockets[i]);
       } else if (socket_state == SRTS_CONNECTED) {
         ReadSocketData(sockets[i]);
       } else {
-        printf("[WARNING] Encountered new socket state, report it to maintainers -> %d\n", socket_state);
+        printf("[WARNING] Encountered new socket state, report it to "
+               "maintainers -> %d\n",
+               socket_state);
       }
     }
 
@@ -214,37 +225,20 @@ int Server::OnNewConnection(SRTSOCKET ns,
     srt_setsockflag(ns, SRTO_LATENCY, &latency_ms, sizeof latency_ms);
   }
 
-  std::unique_lock<std::mutex> lock(accept_mutex);
+  if (stream_ids_whitelist.find(std::string(streamid)) !=
+      stream_ids_whitelist.end()) {
 
-  awaiting_connect_request_socket = ns;
+    this->on_socket_connected(ns, streamid);
+    active_sockets.insert(ns);
+    const int read_modes = SRT_EPOLL_IN | SRT_EPOLL_ERR;
+    srt_epoll_add_usock(epoll, ns, &read_modes);
 
-  this->on_connect_request(address, streamid);
-
-  // NOTE: this check should be very fast as it blocks any receiving on the socket
-  auto result = accept_cv.wait_for(lock, std::chrono::milliseconds(1000));
-
-  if (result == std::cv_status::timeout) {
-    srt_setrejectreason(ns, SRT_REJC_PREDEFINED + 504);
-
-    return -1;
-  } else if (!accept_awaiting_stream_id) {
+    return 0;
+  } else {
     srt_setrejectreason(ns, SRT_REJC_PREDEFINED + 403);
 
     return -1;
   }
-
-  return 0;
-}
-
-void Server::AnswerConnectRequest(int accept) {
-  {
-    std::lock_guard<std::mutex> lock(accept_mutex);
-
-    accept_awaiting_stream_id = accept;
-    awaiting_connect_request_socket = -1;
-  }
-
-  accept_cv.notify_one();
 }
 
 bool Server::IsListeningSocket(Server::SrtSocket socket) const {
@@ -277,26 +271,4 @@ void Server::ReadSocketData(Server::SrtSocket socket) {
   } else {
     this->on_socket_data(socket, buffer, n);
   }
-}
-
-void Server::AcceptConnection() {
-  struct sockaddr_storage their_addr;
-  int addr_len = sizeof their_addr;
-
-  int socket = srt_accept(srt_sock, (struct sockaddr*)&their_addr, &addr_len);
-  if (socket == -1) {
-    throw std::runtime_error("Failed to accept new socket");
-  }
-
-  char raw_streamid[512] = {0};
-  int max_streamid_len = 512;
-  srt_getsockopt(socket, 0, SRTO_STREAMID, raw_streamid, &max_streamid_len);
-
-  auto streamid = std::string(raw_streamid, raw_streamid + max_streamid_len);
-
-  this->on_socket_connected(socket, streamid);
-  active_sockets.insert(socket);
-
-  const int read_modes = SRT_EPOLL_IN | SRT_EPOLL_ERR;
-  srt_epoll_add_usock(epoll, socket, &read_modes);
 }

--- a/c_src/ex_libsrt/server/server.cpp
+++ b/c_src/ex_libsrt/server/server.cpp
@@ -259,14 +259,14 @@ int Server::OnNewConnection(SRTSOCKET ns,
   return 0;
 }
 
-bool Server::BindSocket(SrtSocket socket, std::string& out_stream_id) {
+bool Server::BindSocket(SrtSocket socket, std::string& stream_id) {
   std::lock_guard lock(pending_mutex);
   auto it = pending_connections.find(socket);
   if (it == pending_connections.end()) {
     return false;
   }
 
-  out_stream_id = it->second.first;
+  stream_id = it->second.first;
   pending_connections.erase(it);
 
   active_sockets.insert(socket);

--- a/c_src/ex_libsrt/server/server.cpp
+++ b/c_src/ex_libsrt/server/server.cpp
@@ -237,7 +237,7 @@ int Server::OnNewConnection(SRTSOCKET ns,
   } else {
     srt_setrejectreason(ns, SRT_REJC_PREDEFINED + 403);
 
-    on_client_rejected(std::string(streamid));
+    on_client_rejected(streamid);
 
     return -1;
   }

--- a/c_src/ex_libsrt/server/server.cpp
+++ b/c_src/ex_libsrt/server/server.cpp
@@ -1,5 +1,6 @@
 #include "server.h"
 
+#include <chrono>
 #include <cstring>
 #include <string>
 #include <unifex/unifex.h>
@@ -183,6 +184,20 @@ void Server::RunEpoll() {
         DisconnectSocket(broken_sockets[i]);
       }
     }
+
+    {
+      auto now = std::chrono::steady_clock::now();
+      std::lock_guard lock(pending_mutex);
+      for (auto it = pending_connections.begin();
+           it != pending_connections.end();) {
+        if (now - it->second.second > std::chrono::seconds(1)) {
+          srt_close(it->first);
+          it = pending_connections.erase(it);
+        } else {
+          ++it;
+        }
+      }
+    }
   }
 }
 
@@ -225,22 +240,40 @@ int Server::OnNewConnection(SRTSOCKET ns,
     srt_setsockflag(ns, SRTO_LATENCY, &latency_ms, sizeof latency_ms);
   }
 
-  if (stream_ids_whitelist.find(std::string(streamid)) !=
-      stream_ids_whitelist.end()) {
-
-    this->on_socket_connected(ns, streamid);
-    active_sockets.insert(ns);
-    const int read_modes = SRT_EPOLL_IN | SRT_EPOLL_ERR;
-    srt_epoll_add_usock(epoll, ns, &read_modes);
-
-    return 0;
-  } else {
+  if (!stream_ids_whitelist.empty() &&
+      stream_ids_whitelist.find(std::string(streamid)) ==
+          stream_ids_whitelist.end()) {
     srt_setrejectreason(ns, SRT_REJC_PREDEFINED + 403);
-
     on_client_rejected(streamid);
-
     return -1;
   }
+
+  {
+    std::lock_guard lock(pending_mutex);
+    pending_connections[ns] = {std::string(streamid),
+                               std::chrono::steady_clock::now()};
+  }
+  if (on_client_pending) {
+    on_client_pending(ns, std::string(streamid));
+  }
+  return 0;
+}
+
+bool Server::BindSocket(SrtSocket socket, std::string& out_stream_id) {
+  std::lock_guard lock(pending_mutex);
+  auto it = pending_connections.find(socket);
+  if (it == pending_connections.end()) {
+    return false;
+  }
+
+  out_stream_id = it->second.first;
+  pending_connections.erase(it);
+
+  active_sockets.insert(socket);
+  const int read_modes = SRT_EPOLL_IN | SRT_EPOLL_ERR;
+  srt_epoll_add_usock(epoll, socket, &read_modes);
+
+  return true;
 }
 
 bool Server::IsListeningSocket(Server::SrtSocket socket) const {

--- a/c_src/ex_libsrt/server/server.cpp
+++ b/c_src/ex_libsrt/server/server.cpp
@@ -237,6 +237,8 @@ int Server::OnNewConnection(SRTSOCKET ns,
   } else {
     srt_setrejectreason(ns, SRT_REJC_PREDEFINED + 403);
 
+    on_client_rejected(std::string(streamid));
+
     return -1;
   }
 }

--- a/c_src/ex_libsrt/server/server.cpp
+++ b/c_src/ex_libsrt/server/server.cpp
@@ -11,9 +11,11 @@ void Server::Run(const std::string& address,
                  int port,
                  const std::string& password,
                  int latency_ms,
+                 bool accept_all,
                  std::unordered_set<std::string> ids_whitelist) {
   this->password = password;
   this->latency_ms = latency_ms;
+  this->accept_all = accept_all;
   this->stream_ids_whitelist = std::move(ids_whitelist);
 
   struct sockaddr_storage ss;
@@ -190,7 +192,11 @@ void Server::RunEpoll() {
       std::lock_guard lock(pending_mutex);
       for (auto it = pending_connections.begin();
            it != pending_connections.end();) {
-        if (now - it->second.second > std::chrono::seconds(1)) {
+        if (now - it->second.second >
+            std::chrono::seconds(BIND_RECEIVER_TIMEOUT_SEC)) {
+          if (on_connection_timeout) {
+            on_connection_timeout(it->first, it->second.first);
+          }
           srt_close(it->first);
           it = pending_connections.erase(it);
         } else {
@@ -240,9 +246,8 @@ int Server::OnNewConnection(SRTSOCKET ns,
     srt_setsockflag(ns, SRTO_LATENCY, &latency_ms, sizeof latency_ms);
   }
 
-  if (!stream_ids_whitelist.empty() &&
-      stream_ids_whitelist.find(std::string(streamid)) ==
-          stream_ids_whitelist.end()) {
+  if (!accept_all && stream_ids_whitelist.find(std::string(streamid)) ==
+                         stream_ids_whitelist.end()) {
     srt_setrejectreason(ns, SRT_REJC_PREDEFINED + 403);
     on_client_rejected(streamid);
     return -1;

--- a/c_src/ex_libsrt/server/server.h
+++ b/c_src/ex_libsrt/server/server.h
@@ -13,6 +13,8 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#define BIND_RECEIVER_TIMEOUT_SEC 1
+
 extern "C" {
 #include <arpa/inet.h>
 }
@@ -31,6 +33,7 @@ public:
            int port,
            const std::string& password = "",
            int latency_ms = -1,
+           bool accept_all = false,
            std::unordered_set<std::string> stream_ids_whitelist = {});
 
   void Stop();
@@ -60,6 +63,11 @@ public:
   void SetOnClientPending(
       std::function<void(SrtSocket, const std::string&)> on_client_pending) {
     this->on_client_pending = std::move(on_client_pending);
+  }
+
+  void SetOnConnectionTimeout(
+      std::function<void(SrtSocket, const std::string&)> on_connection_timeout) {
+    this->on_connection_timeout = std::move(on_connection_timeout);
   }
 
   void
@@ -112,7 +120,9 @@ private:
   std::function<void(SrtSocket, const char*, int)> on_socket_data;
   std::function<void(const char*)> on_client_rejected;
   std::function<void(SrtSocket, const std::string&)> on_client_pending;
+  std::function<void(SrtSocket, const std::string&)> on_connection_timeout;
   std::function<void(const std::string&)> on_fatal_error;
+  bool accept_all = false;
   std::unordered_set<std::string> stream_ids_whitelist = {};
 
   using PendingEntry =

--- a/c_src/ex_libsrt/server/server.h
+++ b/c_src/ex_libsrt/server/server.h
@@ -50,8 +50,13 @@ public:
   }
 
   void SetOnSocketData(
-      std::function<void(SrtSocket, const char*, int)>&& on_socket_data) {
+      std::function<void(SrtSocket, const char*, int)> on_socket_data) {
     this->on_socket_data = std::move(on_socket_data);
+  }
+
+  void SetOnClientRejected(
+      std::function<void(const std::string&)> on_client_rejected) {
+    this->on_client_rejected = on_client_rejected;
   }
 
   void
@@ -103,7 +108,7 @@ private:
   std::function<void(SrtSocket, const std::string&)> on_socket_connected;
   std::function<void(SrtSocket)> on_socket_disconnected;
   std::function<void(SrtSocket, const char*, int)> on_socket_data;
+  std::function<void(const std::string&)> on_client_rejected;
   std::function<void(const std::string&)> on_fatal_error;
-
   std::unordered_set<std::string> stream_ids_whitelist = {};
 };

--- a/c_src/ex_libsrt/server/server.h
+++ b/c_src/ex_libsrt/server/server.h
@@ -15,7 +15,7 @@ extern "C" {
 }
 
 class Server {
-  static const int MAX_PENDING_CONNECTIONS = 5;
+  static const int MAX_PENDING_CONNECTIONS = 100;
 
 public:
   using SrtSocket = int;

--- a/c_src/ex_libsrt/server/server.h
+++ b/c_src/ex_libsrt/server/server.h
@@ -1,16 +1,14 @@
 #pragma once
 
+#include "../common/srt_socket_stats.h"
 #include <atomic>
-#include <condition_variable>
 #include <functional>
 #include <memory>
-#include <mutex>
-#include <optional>
+#include <set>
 #include <srt/srt.h>
 #include <string>
 #include <thread>
-#include <set>
-#include "../common/srt_socket_stats.h"
+#include <unordered_set>
 
 extern "C" {
 #include <arpa/inet.h>
@@ -29,7 +27,8 @@ public:
   void Run(const std::string& address,
            int port,
            const std::string& password = "",
-           int latency_ms = -1);
+           int latency_ms = -1,
+           std::unordered_set<std::string> stream_ids_whitelist = {});
 
   void Stop();
 
@@ -37,9 +36,8 @@ public:
 
   void AnswerConnectRequest(int accept);
 
-  SrtSocket GetAwaitingConnectionRequestId() const { return awaiting_connect_request_socket; }
-
-  std::unique_ptr<SrtSocketStats> ReadSocketStats(int socket, bool clear_intervals);
+  std::unique_ptr<SrtSocketStats> ReadSocketStats(int socket,
+                                                  bool clear_intervals);
 
   void SetOnSocketConnected(
       std::function<void(SrtSocket, const std::string&)> on_socket_connected) {
@@ -61,10 +59,12 @@ public:
     this->on_fatal_error = std::move(on_fatal_error);
   }
 
-  void SetOnConnectRequest(
-      std::function<void(const std::string&, const std::string&)>&&
-          on_connect_request) {
-    this->on_connect_request = std::move(on_connect_request);
+  void AddStreamIdToWhitelist(std::string stream_id) {
+    this->stream_ids_whitelist.insert(stream_id);
+  }
+
+  void RemoveStreamIdFromWhitelist(std::string stream_id) {
+    this->stream_ids_whitelist.erase(stream_id);
   }
 
 private:
@@ -74,8 +74,6 @@ private:
 
   void ReadSocketData(SrtSocket socket);
   void DisconnectSocket(SrtSocket socket);
-
-  void AcceptConnection();
 
   void RunEpoll();
 
@@ -106,11 +104,6 @@ private:
   std::function<void(SrtSocket)> on_socket_disconnected;
   std::function<void(SrtSocket, const char*, int)> on_socket_data;
   std::function<void(const std::string&)> on_fatal_error;
-  std::function<void(const std::string&, const std::string&)>
-      on_connect_request;
 
-  std::mutex accept_mutex;
-  std::condition_variable accept_cv;
-  bool accept_awaiting_stream_id = false;
-  SrtSocket awaiting_connect_request_socket = -1;
+  std::unordered_set<std::string> stream_ids_whitelist = {};
 };

--- a/c_src/ex_libsrt/server/server.h
+++ b/c_src/ex_libsrt/server/server.h
@@ -2,12 +2,15 @@
 
 #include "../common/srt_socket_stats.h"
 #include <atomic>
+#include <chrono>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <srt/srt.h>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <unordered_set>
 
 extern "C" {
@@ -34,15 +37,10 @@ public:
 
   void CloseConnection(int connection_id);
 
-  void AnswerConnectRequest(int accept);
+  bool BindSocket(SrtSocket socket, std::string& out_stream_id);
 
   std::unique_ptr<SrtSocketStats> ReadSocketStats(int socket,
                                                   bool clear_intervals);
-
-  void SetOnSocketConnected(
-      std::function<void(SrtSocket, const std::string&)> on_socket_connected) {
-    this->on_socket_connected = std::move(on_socket_connected);
-  };
 
   void SetOnSocketDisconnected(
       std::function<void(SrtSocket)>&& on_socket_disconnected) {
@@ -57,6 +55,11 @@ public:
   void
   SetOnClientRejected(std::function<void(const char*)> on_client_rejected) {
     this->on_client_rejected = on_client_rejected;
+  }
+
+  void SetOnClientPending(
+      std::function<void(SrtSocket, const std::string&)> on_client_pending) {
+    this->on_client_pending = std::move(on_client_pending);
   }
 
   void
@@ -105,10 +108,15 @@ private:
 
 private:
   std::set<SrtSocket> active_sockets;
-  std::function<void(SrtSocket, const std::string&)> on_socket_connected;
   std::function<void(SrtSocket)> on_socket_disconnected;
   std::function<void(SrtSocket, const char*, int)> on_socket_data;
   std::function<void(const char*)> on_client_rejected;
+  std::function<void(SrtSocket, const std::string&)> on_client_pending;
   std::function<void(const std::string&)> on_fatal_error;
   std::unordered_set<std::string> stream_ids_whitelist = {};
+
+  using PendingEntry =
+      std::pair<std::string, std::chrono::steady_clock::time_point>;
+  std::unordered_map<SrtSocket, PendingEntry> pending_connections;
+  std::mutex pending_mutex;
 };

--- a/c_src/ex_libsrt/server/server.h
+++ b/c_src/ex_libsrt/server/server.h
@@ -54,8 +54,8 @@ public:
     this->on_socket_data = std::move(on_socket_data);
   }
 
-  void SetOnClientRejected(
-      std::function<void(const std::string&)> on_client_rejected) {
+  void
+  SetOnClientRejected(std::function<void(const char*)> on_client_rejected) {
     this->on_client_rejected = on_client_rejected;
   }
 
@@ -108,7 +108,7 @@ private:
   std::function<void(SrtSocket, const std::string&)> on_socket_connected;
   std::function<void(SrtSocket)> on_socket_disconnected;
   std::function<void(SrtSocket, const char*, int)> on_socket_data;
-  std::function<void(const std::string&)> on_client_rejected;
+  std::function<void(const char*)> on_client_rejected;
   std::function<void(const std::string&)> on_fatal_error;
   std::unordered_set<std::string> stream_ids_whitelist = {};
 };

--- a/c_src/ex_libsrt/srt_nif.cpp
+++ b/c_src/ex_libsrt/srt_nif.cpp
@@ -133,6 +133,7 @@ UNIFEX_TERM start_server(UnifexEnv* env,
                          int port,
                          char* password,
                          int latency_ms,
+                         int accept_all,
                          char** stream_ids_whitelist,
                          unsigned int stream_ids_whitelist_length,
                          UnifexPid owner) {
@@ -189,6 +190,12 @@ UNIFEX_TERM start_server(UnifexEnv* env,
               state->env, state->owner, 1, socket, stream_id.c_str());
         });
 
+    state->server->SetOnConnectionTimeout(
+        [=](Server::SrtSocket socket, const std::string& stream_id) {
+          send_srt_server_conn_timeout(
+              state->env, state->owner, 1, socket, stream_id.c_str());
+        });
+
     std::unordered_set<std::string> stream_ids_whitelist_set(
         stream_ids_whitelist,
         stream_ids_whitelist + stream_ids_whitelist_length);
@@ -197,6 +204,7 @@ UNIFEX_TERM start_server(UnifexEnv* env,
                        port,
                        std::string(password),
                        latency_ms,
+                       static_cast<bool>(accept_all),
                        std::move(stream_ids_whitelist_set));
 
     UNIFEX_TERM result = start_server_result_ok(env, state);

--- a/c_src/ex_libsrt/srt_nif.cpp
+++ b/c_src/ex_libsrt/srt_nif.cpp
@@ -197,6 +197,11 @@ UNIFEX_TERM start_server(UnifexEnv* env,
           unifex_free(payload);
         });
 
+    state->server->SetOnClientRejected([=](std::string stream_id) {
+      send_srt_server_rejected_client(
+          state->env, state->owner, 1, stream_id.c_str());
+    });
+
     std::unordered_set<std::string> stream_ids_whitelist_set(
         stream_ids_whitelist,
         stream_ids_whitelist + stream_ids_whitelist_length);

--- a/c_src/ex_libsrt/srt_nif.cpp
+++ b/c_src/ex_libsrt/srt_nif.cpp
@@ -225,15 +225,13 @@ UNIFEX_TERM remove_stream_id_from_whitelist(UnifexEnv* env,
 }
 
 UNIFEX_TERM bind_with_process(UnifexEnv* env,
-                           int conn_id,
-                           UnifexPid receiver,
-                           UnifexState* state) {
+                              int conn_id,
+                              UnifexPid receiver,
+                              UnifexState* state) {
   if (state->server == nullptr) {
     return bind_with_process_result_error(env, "Server is not active");
   }
 
-  // Register receiver before activating the socket so no data packet can
-  // arrive on the epoll thread between BindSocket and conn_receivers.insert
   {
     std::lock_guard lock(state->conn_receivers_mutex);
     state->conn_receivers.insert({conn_id, receiver});
@@ -243,7 +241,8 @@ UNIFEX_TERM bind_with_process(UnifexEnv* env,
   if (!state->server->BindSocket(conn_id, stream_id)) {
     std::lock_guard lock(state->conn_receivers_mutex);
     state->conn_receivers.erase(conn_id);
-    return bind_with_process_result_error(env, "Connection not found or timed out");
+    return bind_with_process_result_error(env,
+                                          "Connection not found or timed out");
   }
 
   return bind_with_process_result_ok(env, stream_id.c_str());

--- a/c_src/ex_libsrt/srt_nif.cpp
+++ b/c_src/ex_libsrt/srt_nif.cpp
@@ -1,7 +1,6 @@
 #include "srt_nif.h"
 #include "ex_libsrt/_generated/nif/srt_nif.h"
 #include "unifex/unifex.h"
-#include <cassert>
 #include <cstdlib>
 #include <iterator>
 #include <unordered_set>
@@ -12,7 +11,7 @@
 static void close_all_connections(State* state) {
   std::vector<int> conn_ids;
   {
-    std::shared_lock lock(state->conn_receivers_mutex);
+    std::lock_guard lock(state->conn_receivers_mutex);
     conn_ids.reserve(state->conn_receivers.size());
     for (const auto& entry : state->conn_receivers) {
       conn_ids.push_back(entry.first);
@@ -136,8 +135,6 @@ UNIFEX_TERM start_server(UnifexEnv* env,
                          int latency_ms,
                          char** stream_ids_whitelist,
                          unsigned int stream_ids_whitelist_length,
-                         UnifexPid* receivers,
-                         unsigned int receivers_length,
                          UnifexPid owner) {
   State* state = unifex_alloc_state(env);
   state = new (state) State();
@@ -147,20 +144,6 @@ UNIFEX_TERM start_server(UnifexEnv* env,
     state->owner = owner;
 
     state->server = std::make_unique<Server>();
-
-    state->server->SetOnSocketConnected(
-        [=](Server::SrtSocket socket, const std::string& stream_id) {
-          std::lock_guard conn_receivers_lock(state->conn_receivers_mutex);
-          std::shared_lock whitelist_lock(state->whitelist_mutex);
-
-          if (auto it = state->stream_id_to_receiver_map.find(stream_id);
-              it != std::end(state->stream_id_to_receiver_map)) {
-            state->conn_receivers.insert({socket, it->second});
-
-            send_srt_server_conn(
-                state->env, it->second, 1, socket, stream_id.c_str());
-          }
-        });
 
     state->server->SetOnSocketDisconnected([=](Server::SrtSocket socket) {
       std::lock_guard lock(state->conn_receivers_mutex);
@@ -183,7 +166,7 @@ UNIFEX_TERM start_server(UnifexEnv* env,
           memcpy(payload->data, data, len);
 
           {
-            std::unique_lock lock(state->conn_receivers_mutex);
+            std::lock_guard lock(state->conn_receivers_mutex);
             if (auto it = state->conn_receivers.find(socket);
                 it != std::end(state->conn_receivers)) {
               // TODO: make sure that the message has been properly sent
@@ -200,16 +183,15 @@ UNIFEX_TERM start_server(UnifexEnv* env,
       send_srt_server_rejected_client(state->env, state->owner, 1, stream_id);
     });
 
+    state->server->SetOnClientPending(
+        [=](Server::SrtSocket socket, const std::string& stream_id) {
+          send_srt_server_conn(
+              state->env, state->owner, 1, socket, stream_id.c_str());
+        });
+
     std::unordered_set<std::string> stream_ids_whitelist_set(
         stream_ids_whitelist,
         stream_ids_whitelist + stream_ids_whitelist_length);
-
-    std::lock_guard lock(state->whitelist_mutex);
-    assert(stream_ids_whitelist_length == receivers_length);
-    for (unsigned int i = 0; i < receivers_length; i++) {
-      state->stream_id_to_receiver_map.insert(
-          {stream_ids_whitelist[i], receivers[i]});
-    }
 
     state->server->Run(std::string(address),
                        port,
@@ -230,25 +212,41 @@ UNIFEX_TERM start_server(UnifexEnv* env,
 
 UNIFEX_TERM add_stream_id_to_whitelist(UnifexEnv* env,
                                        char* stream_id,
-                                       UnifexPid receiver,
                                        UnifexState* state) {
-
-  std::lock_guard lock(state->whitelist_mutex);
   state->server->AddStreamIdToWhitelist(stream_id);
-  state->stream_id_to_receiver_map.insert({std::string(stream_id), receiver});
-
   return add_stream_id_to_whitelist_result_ok(env);
 }
 
 UNIFEX_TERM remove_stream_id_from_whitelist(UnifexEnv* env,
                                             char* stream_id,
                                             UnifexState* state) {
-
-  std::lock_guard lock(state->whitelist_mutex);
   state->server->RemoveStreamIdFromWhitelist(stream_id);
-  state->stream_id_to_receiver_map.erase(std::string(stream_id));
-
   return remove_stream_id_from_whitelist_result_ok(env);
+}
+
+UNIFEX_TERM bind_with_process(UnifexEnv* env,
+                           int conn_id,
+                           UnifexPid receiver,
+                           UnifexState* state) {
+  if (state->server == nullptr) {
+    return bind_with_process_result_error(env, "Server is not active");
+  }
+
+  // Register receiver before activating the socket so no data packet can
+  // arrive on the epoll thread between BindSocket and conn_receivers.insert
+  {
+    std::lock_guard lock(state->conn_receivers_mutex);
+    state->conn_receivers.insert({conn_id, receiver});
+  }
+
+  std::string stream_id;
+  if (!state->server->BindSocket(conn_id, stream_id)) {
+    std::lock_guard lock(state->conn_receivers_mutex);
+    state->conn_receivers.erase(conn_id);
+    return bind_with_process_result_error(env, "Connection not found or timed out");
+  }
+
+  return bind_with_process_result_ok(env, stream_id.c_str());
 }
 
 UNIFEX_TERM

--- a/c_src/ex_libsrt/srt_nif.cpp
+++ b/c_src/ex_libsrt/srt_nif.cpp
@@ -151,7 +151,9 @@ UNIFEX_TERM start_server(UnifexEnv* env,
 
     state->server->SetOnSocketConnected(
         [=](Server::SrtSocket socket, const std::string& stream_id) {
-          std::lock_guard lock(state->conn_receivers_mutex);
+          std::lock_guard conn_receivers_lock(state->conn_receivers_mutex);
+          std::shared_lock whitelist_lock(state->whitelist_mutex);
+
           if (auto it = state->stream_id_to_receiver_map.find(stream_id);
               it != std::end(state->stream_id_to_receiver_map)) {
             state->conn_receivers.insert({socket, it->second});
@@ -199,6 +201,7 @@ UNIFEX_TERM start_server(UnifexEnv* env,
         stream_ids_whitelist,
         stream_ids_whitelist + stream_ids_whitelist_length);
 
+    std::lock_guard lock(state->whitelist_mutex);
     assert(stream_ids_whitelist_length == receivers_length);
     for (unsigned int i = 0; i < receivers_length; i++) {
       state->stream_id_to_receiver_map.insert(
@@ -227,6 +230,7 @@ UNIFEX_TERM add_stream_id_to_whitelist(UnifexEnv* env,
                                        UnifexPid receiver,
                                        UnifexState* state) {
 
+  std::lock_guard lock(state->whitelist_mutex);
   state->server->AddStreamIdToWhitelist(stream_id);
   state->stream_id_to_receiver_map.insert({std::string(stream_id), receiver});
 
@@ -237,6 +241,7 @@ UNIFEX_TERM remove_stream_id_from_whitelist(UnifexEnv* env,
                                             char* stream_id,
                                             UnifexState* state) {
 
+  std::lock_guard lock(state->whitelist_mutex);
   state->server->RemoveStreamIdFromWhitelist(stream_id);
   state->stream_id_to_receiver_map.erase(std::string(stream_id));
 

--- a/c_src/ex_libsrt/srt_nif.cpp
+++ b/c_src/ex_libsrt/srt_nif.cpp
@@ -197,9 +197,8 @@ UNIFEX_TERM start_server(UnifexEnv* env,
           unifex_free(payload);
         });
 
-    state->server->SetOnClientRejected([=](std::string stream_id) {
-      send_srt_server_rejected_client(
-          state->env, state->owner, 1, stream_id.c_str());
+    state->server->SetOnClientRejected([=](const char* stream_id) {
+      send_srt_server_rejected_client(state->env, state->owner, 1, stream_id);
     });
 
     std::unordered_set<std::string> stream_ids_whitelist_set(

--- a/c_src/ex_libsrt/srt_nif.cpp
+++ b/c_src/ex_libsrt/srt_nif.cpp
@@ -137,15 +137,14 @@ UNIFEX_TERM start_server(UnifexEnv* env,
                          char** stream_ids_whitelist,
                          unsigned int stream_ids_whitelist_length,
                          UnifexPid* receivers,
-                         unsigned int receivers_length) {
+                         unsigned int receivers_length,
+                         UnifexPid owner) {
   State* state = unifex_alloc_state(env);
   state = new (state) State();
 
   try {
     state->env = unifex_alloc_env(env);
-    if (!unifex_self(env, &state->owner)) {
-      throw std::runtime_error("failed to create native state");
-    };
+    state->owner = owner;
 
     state->server = std::make_unique<Server>();
 

--- a/c_src/ex_libsrt/srt_nif.cpp
+++ b/c_src/ex_libsrt/srt_nif.cpp
@@ -1,6 +1,10 @@
 #include "srt_nif.h"
+#include "ex_libsrt/_generated/nif/srt_nif.h"
+#include "unifex/unifex.h"
+#include <cassert>
 #include <cstdlib>
-#include <thread>
+#include <iterator>
+#include <unordered_set>
 #include <vector>
 
 #include <srt/srt.h>
@@ -129,7 +133,11 @@ UNIFEX_TERM start_server(UnifexEnv* env,
                          char* address,
                          int port,
                          char* password,
-                         int latency_ms) {
+                         int latency_ms,
+                         char** stream_ids_whitelist,
+                         unsigned int stream_ids_whitelist_length,
+                         UnifexPid* receivers,
+                         unsigned int receivers_length) {
   State* state = unifex_alloc_state(env);
   state = new (state) State();
 
@@ -144,18 +152,20 @@ UNIFEX_TERM start_server(UnifexEnv* env,
     state->server->SetOnSocketConnected(
         [=](Server::SrtSocket socket, const std::string& stream_id) {
           std::lock_guard lock(state->conn_receivers_mutex);
+          if (auto it = state->stream_id_to_receiver_map.find(stream_id);
+              it != std::end(state->stream_id_to_receiver_map)) {
+            state->conn_receivers.insert({socket, it->second});
 
-          if (auto it = state->conn_receivers.find(socket); it != std::end(state->conn_receivers)) {
             send_srt_server_conn(
                 state->env, it->second, 1, socket, stream_id.c_str());
           }
-
         });
 
     state->server->SetOnSocketDisconnected([=](Server::SrtSocket socket) {
       std::lock_guard lock(state->conn_receivers_mutex);
 
-      if (auto it = state->conn_receivers.find(socket); it != std::end(state->conn_receivers)) {
+      if (auto it = state->conn_receivers.find(socket);
+          it != std::end(state->conn_receivers)) {
         send_srt_server_conn_closed(state->env, it->second, 1, socket);
       }
 
@@ -173,7 +183,8 @@ UNIFEX_TERM start_server(UnifexEnv* env,
 
           {
             std::unique_lock lock(state->conn_receivers_mutex);
-            if (auto it = state->conn_receivers.find(socket); it != std::end(state->conn_receivers)) {
+            if (auto it = state->conn_receivers.find(socket);
+                it != std::end(state->conn_receivers)) {
               // TODO: make sure that the message has been properly sent
               send_srt_data(state->env, it->second, 1, socket, payload);
             }
@@ -184,13 +195,21 @@ UNIFEX_TERM start_server(UnifexEnv* env,
           unifex_free(payload);
         });
 
-    state->server->SetOnConnectRequest(
-        [=](const std::string& address, const std::string& stream_id) {
-          send_srt_server_connect_request(
-              state->env, state->owner, 1, address.c_str(), stream_id.c_str());
-        });
+    std::unordered_set<std::string> stream_ids_whitelist_set(
+        stream_ids_whitelist,
+        stream_ids_whitelist + stream_ids_whitelist_length);
 
-    state->server->Run(std::string(address), port, std::string(password), latency_ms);
+    assert(stream_ids_whitelist_length == receivers_length);
+    for (unsigned int i = 0; i < receivers_length; i++) {
+      state->stream_id_to_receiver_map.insert(
+          {stream_ids_whitelist[i], receivers[i]});
+    }
+
+    state->server->Run(std::string(address),
+                       port,
+                       std::string(password),
+                       latency_ms,
+                       std::move(stream_ids_whitelist_set));
 
     UNIFEX_TERM result = start_server_result_ok(env, state);
     unifex_release_state(env, state);
@@ -203,22 +222,29 @@ UNIFEX_TERM start_server(UnifexEnv* env,
   }
 }
 
-UNIFEX_TERM accept_awaiting_connect_request(UnifexEnv *env, UnifexPid receiver,
-                                            UnifexState *state) {
-  if (state->server == nullptr) {
-    return accept_awaiting_connect_request_result_error(env, "Server is not active");
-  }
+UNIFEX_TERM add_stream_id_to_whitelist(UnifexEnv* env,
+                                       char* stream_id,
+                                       UnifexPid receiver,
+                                       UnifexState* state) {
 
-  auto id = state->server->GetAwaitingConnectionRequestId();
-  state->server->AnswerConnectRequest(true);
+  state->server->AddStreamIdToWhitelist(stream_id);
+  state->stream_id_to_receiver_map.insert({std::string(stream_id), receiver});
 
-  std::lock_guard lock(state->conn_receivers_mutex);
-  state->conn_receivers.insert({id, receiver});
-
-  return accept_awaiting_connect_request_result_ok(env);
+  return add_stream_id_to_whitelist_result_ok(env);
 }
 
-UNIFEX_TERM read_server_socket_stats(UnifexEnv* env, int conn_id, UnifexState* state) {
+UNIFEX_TERM remove_stream_id_from_whitelist(UnifexEnv* env,
+                                            char* stream_id,
+                                            UnifexState* state) {
+
+  state->server->RemoveStreamIdFromWhitelist(stream_id);
+  state->stream_id_to_receiver_map.erase(std::string(stream_id));
+
+  return remove_stream_id_from_whitelist_result_ok(env);
+}
+
+UNIFEX_TERM
+read_server_socket_stats(UnifexEnv* env, int conn_id, UnifexState* state) {
   if (state->server == nullptr) {
     return read_server_socket_stats_result_error(env, "Server is not active");
   }
@@ -232,18 +258,6 @@ UNIFEX_TERM read_server_socket_stats(UnifexEnv* env, int conn_id, UnifexState* s
 
   return read_server_socket_stats_result_ok(env, srt_stats);
 }
-
-UNIFEX_TERM reject_awaiting_connect_request(UnifexEnv* env,
-                                            UnifexState* state) {
-  if (state->server == nullptr) {
-    return accept_awaiting_connect_request_result_error(env, "Server is not active");
-  }
-
-  state->server->AnswerConnectRequest(false);
-
-  return accept_awaiting_connect_request_result_ok(env);
-}
-
 
 UNIFEX_TERM stop_server(UnifexEnv* env, UnifexState* state) {
   if (state->server == nullptr) {
@@ -260,7 +274,7 @@ UNIFEX_TERM stop_server(UnifexEnv* env, UnifexState* state) {
 UNIFEX_TERM
 close_server_connection(UnifexEnv* env, int conn_id, UnifexState* state) {
   if (state->server == nullptr) {
-    return accept_awaiting_connect_request_result_error(env, "Server is not active");
+    return close_server_connection_result_error(env, "Server is not active");
   }
 
   if (state->server) {
@@ -321,12 +335,11 @@ start_client(UnifexEnv* env,
   }
 }
 
-
 UNIFEX_TERM
 send_client_data(UnifexEnv* env, UnifexPayload* payload, UnifexState* state) {
   if (state->client == nullptr) {
     return send_client_data_result_error(env, "Client is not active");
-  } 
+  }
 
   try {
     auto buffer = std::unique_ptr<char[]>(new char[payload->size]);
@@ -348,7 +361,8 @@ UNIFEX_TERM read_client_socket_stats(UnifexEnv* env, UnifexState* state) {
 
   auto stats = state->client->ReadSocketStats(true);
   if (!stats) {
-    return read_client_socket_stats_result_error(env, "Failed to read client socket stats");
+    return read_client_socket_stats_result_error(
+        env, "Failed to read client socket stats");
   }
 
   auto srt_stats = map_socket_stats(stats.get());

--- a/c_src/ex_libsrt/srt_nif.h
+++ b/c_src/ex_libsrt/srt_nif.h
@@ -3,6 +3,7 @@
 #include "client/client.h"
 #include "server/server.h"
 #include <memory>
+#include <mutex>
 #include <shared_mutex>
 #include <unifex/unifex.h>
 #include <unordered_map>
@@ -13,6 +14,7 @@ typedef struct SRTState {
   std::unordered_map<int, UnifexPid> conn_receivers;
   std::unordered_map<std::string, UnifexPid> stream_id_to_receiver_map;
   std::shared_mutex conn_receivers_mutex;
+  std::shared_mutex whitelist_mutex;
   std::unique_ptr<Server> server;
   std::unique_ptr<Client> client;
 } State;

--- a/c_src/ex_libsrt/srt_nif.h
+++ b/c_src/ex_libsrt/srt_nif.h
@@ -5,11 +5,13 @@
 #include <memory>
 #include <shared_mutex>
 #include <unifex/unifex.h>
+#include <unordered_map>
 
 typedef struct SRTState {
   UnifexPid owner;
   UnifexEnv* env;
-  std::unordered_map<int, UnifexPid> conn_receivers; 
+  std::unordered_map<int, UnifexPid> conn_receivers;
+  std::unordered_map<std::string, UnifexPid> stream_id_to_receiver_map;
   std::shared_mutex conn_receivers_mutex;
   std::unique_ptr<Server> server;
   std::unique_ptr<Client> client;

--- a/c_src/ex_libsrt/srt_nif.h
+++ b/c_src/ex_libsrt/srt_nif.h
@@ -4,7 +4,6 @@
 #include "server/server.h"
 #include <memory>
 #include <mutex>
-#include <shared_mutex>
 #include <unifex/unifex.h>
 #include <unordered_map>
 
@@ -12,9 +11,7 @@ typedef struct SRTState {
   UnifexPid owner;
   UnifexEnv* env;
   std::unordered_map<int, UnifexPid> conn_receivers;
-  std::unordered_map<std::string, UnifexPid> stream_id_to_receiver_map;
-  std::shared_mutex conn_receivers_mutex;
-  std::shared_mutex whitelist_mutex;
+  std::mutex conn_receivers_mutex;
   std::unique_ptr<Server> server;
   std::unique_ptr<Client> client;
 } State;

--- a/c_src/ex_libsrt/srt_nif.spec.exs
+++ b/c_src/ex_libsrt/srt_nif.spec.exs
@@ -87,6 +87,7 @@ sends {:srt_server_conn :: label, conn :: int, stream_id :: string}
 sends {:srt_server_conn_closed:: label, conn :: int}
 sends {:srt_server_error :: label, conn :: int, error :: string}
 sends {:srt_data :: label, conn :: int, data :: payload}
+sends {:srt_server_rejected_client :: label, stream_id :: string}
 
 sends :srt_client_connected :: label
 sends :srt_client_disconnected :: label

--- a/c_src/ex_libsrt/srt_nif.spec.exs
+++ b/c_src/ex_libsrt/srt_nif.spec.exs
@@ -63,7 +63,7 @@ type srt_socket_stats :: %ExLibSRT.SocketStats{
 callback :load, :on_load
 callback :unload, :on_unload
 
-spec start_server(host :: string, port :: int, password :: string, latency_ms :: int, stream_ids_whitelist :: [string], owner :: pid) :: {:ok :: label, state} | {:error :: label, reason :: string}
+spec start_server(host :: string, port :: int, password :: string, latency_ms :: int, accept_all :: bool, stream_ids_whitelist :: [string], owner :: pid) :: {:ok :: label, state} | {:error :: label, reason :: string}
 
 spec add_stream_id_to_whitelist(stream_id :: string, state) :: (:ok :: label)
 
@@ -90,9 +90,10 @@ sends {:srt_server_conn_closed:: label, conn :: int}
 sends {:srt_server_error :: label, conn :: int, error :: string}
 sends {:srt_data :: label, conn :: int, data :: payload}
 sends {:srt_server_rejected_client :: label, stream_id :: string}
+sends {:srt_server_conn_timeout :: label, conn_id :: int, stream_id :: string}
 
 sends :srt_client_connected :: label
 sends :srt_client_disconnected :: label
 sends {:srt_client_error :: label, reason :: string}
 
-dirty :io,  start_server: 6, bind_with_process: 3, close_server_connection: 2, stop_server: 1, start_client: 5, read_server_socket_stats: 2, read_client_socket_stats: 1
+dirty :io,  start_server: 7, bind_with_process: 3, close_server_connection: 2, stop_server: 1, start_client: 5, read_server_socket_stats: 2, read_client_socket_stats: 1

--- a/c_src/ex_libsrt/srt_nif.spec.exs
+++ b/c_src/ex_libsrt/srt_nif.spec.exs
@@ -63,7 +63,7 @@ type srt_socket_stats :: %ExLibSRT.SocketStats{
 callback :load, :on_load
 callback :unload, :on_unload
 
-spec start_server(host :: string, port :: int, password :: string, latency_ms :: int, stream_ids_whitelist :: [string], receivers :: [pid]) :: {:ok :: label, state} | {:error :: label, reason :: string}
+spec start_server(host :: string, port :: int, password :: string, latency_ms :: int, stream_ids_whitelist :: [string], receivers :: [pid], owner :: pid) :: {:ok :: label, state} | {:error :: label, reason :: string}
 
 spec add_stream_id_to_whitelist(stream_id :: string, receiver :: pid, state) :: (:ok :: label)
 
@@ -93,4 +93,4 @@ sends :srt_client_connected :: label
 sends :srt_client_disconnected :: label
 sends {:srt_client_error :: label, reason :: string}
 
-dirty :io,  start_server: 6, close_server_connection: 2, stop_server: 1, start_client: 5, read_server_socket_stats: 2, read_client_socket_stats: 1
+dirty :io,  start_server: 7, close_server_connection: 2, stop_server: 1, start_client: 5, read_server_socket_stats: 2, read_client_socket_stats: 1

--- a/c_src/ex_libsrt/srt_nif.spec.exs
+++ b/c_src/ex_libsrt/srt_nif.spec.exs
@@ -63,18 +63,17 @@ type srt_socket_stats :: %ExLibSRT.SocketStats{
 callback :load, :on_load
 callback :unload, :on_unload
 
-spec start_server(host :: string, port :: int, password :: string, latency_ms :: int) :: {:ok :: label, state} | {:error :: label, reason :: string}
+spec start_server(host :: string, port :: int, password :: string, latency_ms :: int, stream_ids_whitelist :: [string], receivers :: [pid]) :: {:ok :: label, state} | {:error :: label, reason :: string}
 
-spec accept_awaiting_connect_request(receiver :: pid, state) :: (:ok :: label) | {:error :: label, reason :: string}
+spec add_stream_id_to_whitelist(stream_id :: string, receiver :: pid, state) :: (:ok :: label)
 
-spec reject_awaiting_connect_request(state) :: (:ok :: label) | {:error :: label, reason :: string}
+spec remove_stream_id_from_whitelist(stream_id :: string, state) :: (:ok :: label)
 
 spec read_server_socket_stats(conn_id :: int, state) :: {:ok :: label, stats :: srt_socket_stats} | {:error :: label, reason :: string}
 
 spec close_server_connection(conn_id :: int, state) :: (:ok :: label) | {:error :: label, reason :: string}
 
 spec stop_server(state) :: (:ok :: label) | {:error :: label, reason :: string}
-
 
 spec start_client(server_address :: string, port :: int, stream_id :: string, password :: string, latency_ms :: int) :: {:ok :: label, state} | {:error :: label, reason :: string, code :: int}
 
@@ -88,10 +87,9 @@ sends {:srt_server_conn :: label, conn :: int, stream_id :: string}
 sends {:srt_server_conn_closed:: label, conn :: int}
 sends {:srt_server_error :: label, conn :: int, error :: string}
 sends {:srt_data :: label, conn :: int, data :: payload}
-sends {:srt_server_connect_request :: label, address :: string, stream_id :: string}
 
 sends :srt_client_connected :: label
 sends :srt_client_disconnected :: label
 sends {:srt_client_error :: label, reason :: string}
 
-dirty :io,  start_server: 4, close_server_connection: 2, stop_server: 1, start_client: 5, read_server_socket_stats: 2, read_client_socket_stats: 1
+dirty :io,  start_server: 6, close_server_connection: 2, stop_server: 1, start_client: 5, read_server_socket_stats: 2, read_client_socket_stats: 1

--- a/c_src/ex_libsrt/srt_nif.spec.exs
+++ b/c_src/ex_libsrt/srt_nif.spec.exs
@@ -63,13 +63,15 @@ type srt_socket_stats :: %ExLibSRT.SocketStats{
 callback :load, :on_load
 callback :unload, :on_unload
 
-spec start_server(host :: string, port :: int, password :: string, latency_ms :: int, stream_ids_whitelist :: [string], receivers :: [pid], owner :: pid) :: {:ok :: label, state} | {:error :: label, reason :: string}
+spec start_server(host :: string, port :: int, password :: string, latency_ms :: int, stream_ids_whitelist :: [string], owner :: pid) :: {:ok :: label, state} | {:error :: label, reason :: string}
 
-spec add_stream_id_to_whitelist(stream_id :: string, receiver :: pid, state) :: (:ok :: label)
+spec add_stream_id_to_whitelist(stream_id :: string, state) :: (:ok :: label)
 
 spec remove_stream_id_from_whitelist(stream_id :: string, state) :: (:ok :: label)
 
 spec read_server_socket_stats(conn_id :: int, state) :: {:ok :: label, stats :: srt_socket_stats} | {:error :: label, reason :: string}
+
+spec bind_with_process(conn_id :: int, receiver :: pid, state) :: {:ok :: label, stream_id :: string} | {:error :: label, reason :: string}
 
 spec close_server_connection(conn_id :: int, state) :: (:ok :: label) | {:error :: label, reason :: string}
 
@@ -93,4 +95,4 @@ sends :srt_client_connected :: label
 sends :srt_client_disconnected :: label
 sends {:srt_client_error :: label, reason :: string}
 
-dirty :io,  start_server: 7, close_server_connection: 2, stop_server: 1, start_client: 5, read_server_socket_stats: 2, read_client_socket_stats: 1
+dirty :io,  start_server: 6, bind_with_process: 3, close_server_connection: 2, stop_server: 1, start_client: 5, read_server_socket_stats: 2, read_client_socket_stats: 1

--- a/examples/connection_handler.exs
+++ b/examples/connection_handler.exs
@@ -14,15 +14,6 @@ defmodule ConnectionHandler do
   end
 
   @impl true
-  def handle_connected(conn_id, stream_id, state) do
-    Logger.info("Connected with conn_id: #{conn_id} and stream_id: #{stream_id}")
-
-    Registry.register(state.registry, "connections", conn_id)
-
-    {:ok, Map.put(state, :conn_id, conn_id)}
-  end
-
-  @impl true
   def handle_disconnected(state) do
     Logger.info("Connection closed conn_id: #{state.conn_id}")
     :ok

--- a/examples/connection_handler.exs
+++ b/examples/connection_handler.exs
@@ -24,7 +24,7 @@ defmodule ConnectionHandler do
 
   @impl true
   def handle_disconnected(state) do
-  Logger.info("Connection closed conn_id: #{state.conn_id}")
+    Logger.info("Connection closed conn_id: #{state.conn_id}")
     :ok
   end
 
@@ -54,10 +54,19 @@ defmodule Server do
     GenServer.call(server, {:close_connection, conn_id})
   end
 
-
   @impl true
   def init(_args) do
-    {:ok, server} = ExLibSRT.Server.start("0.0.0.0", 12_000)
+    stream_ids = ["some_stream_id_1", "some_stream_id_2", "some_stream_id_3"]
+
+    receivers =
+      Enum.map(stream_ids, fn stream_id ->
+        {:ok, handler} =
+          ExLibSRT.Connection.start(%ConnectionHandler{registry: ConnectionRegistry})
+
+        {stream_id, handler}
+      end)
+
+    {:ok, server} = ExLibSRT.Server.start("0.0.0.0", 12_000, "", -1, receivers)
 
     {:ok, server}
   end
@@ -77,15 +86,6 @@ defmodule Server do
   end
 
   @impl true
-  def handle_info({:srt_server_connect_request, address, stream_id}, server) do
-    Logger.info("Receiving new connection request with stream id: #{stream_id} from address: #{address}")
-
-    {:ok, _handler} = ExLibSRT.Server.accept_awaiting_connect_request_with_handler(%ConnectionHandler{registry: ConnectionRegistry}, server)
-
-    {:noreply, server}
-  end
-
-  @impl true
   def terminate(_reason, _server) do
     Logger.info("Terminating server")
   end
@@ -96,17 +96,18 @@ end
 {:ok, server} = Server.start_link()
 
 
-clients = for i <- 1..3 do
-  {:ok, client} = ExLibSRT.Client.start("127.0.0.1", 12_000, "some_stream_id_#{i}")
+clients =
+  for i <- 1..3 do
+    {:ok, client} = ExLibSRT.Client.start("127.0.0.1", 12_000, "some_stream_id_#{i}")
 
-  receive do
-    :srt_client_connected -> :ok
+    receive do
+      :srt_client_connected -> :ok
+    end
+
+    client
   end
 
-  client
-end
-
-Enum.each(clients, & ExLibSRT.Client.send_data("Hello world!", &1))
+Enum.each(clients, &ExLibSRT.Client.send_data("Hello world!", &1))
 
 Process.sleep(200)
 
@@ -114,7 +115,9 @@ Registry.dispatch(ConnectionRegistry, "connections", fn entries ->
   for {_pid, conn_id} <- entries do
     stats = Server.statistics(server, conn_id)
 
-    IO.puts("Statistics for socket: #{conn_id}: #{inspect(Map.take(stats, [:byteRecvTotal, :pktRecv, :pktSentACK]))}")
+    IO.puts(
+      "Statistics for socket: #{conn_id}: #{inspect(Map.take(stats, [:byteRecvTotal, :pktRecv, :pktSentACK]))}"
+    )
 
     Server.close_connection(server, conn_id)
   end
@@ -123,4 +126,3 @@ end)
 Process.sleep(2_000)
 
 GenServer.stop(server)
-

--- a/examples/connection_handler.exs
+++ b/examples/connection_handler.exs
@@ -66,9 +66,16 @@ defmodule Server do
         {stream_id, handler}
       end)
 
-    {:ok, server} = ExLibSRT.Server.start("0.0.0.0", 12_000, "", -1, receivers)
+    {:ok, server} = ExLibSRT.Server.start("0.0.0.0", 12_000, "", -1, receivers, self())
 
     {:ok, server}
+  end
+
+  @impl true
+  def handle_info({:srt_server_rejected_client, stream_id}, server) do
+    Logger.warning("Rejected connection attempt for unknown stream ID: #{stream_id}")
+
+    {:noreply, server}
   end
 
   @impl true

--- a/examples/connection_handler.exs
+++ b/examples/connection_handler.exs
@@ -58,17 +58,21 @@ defmodule Server do
   def init(_args) do
     stream_ids = ["some_stream_id_1", "some_stream_id_2", "some_stream_id_3"]
 
-    receivers =
-      Enum.map(stream_ids, fn stream_id ->
-        {:ok, handler} =
-          ExLibSRT.Connection.start(%ConnectionHandler{registry: ConnectionRegistry})
-
-        {stream_id, handler}
-      end)
-
-    {:ok, server} = ExLibSRT.Server.start("0.0.0.0", 12_000, "", -1, receivers, self())
+    {:ok, server} = ExLibSRT.Server.start("0.0.0.0", 12_000, "", -1, stream_ids, self())
 
     {:ok, server}
+  end
+
+  @impl true
+  def handle_info({:srt_server_conn, conn_id, _stream_id}, server) do
+    {:ok, _conn} =
+      ExLibSRT.Server.bind_with_handler(
+        %ConnectionHandler{registry: ConnectionRegistry},
+        server,
+        conn_id
+      )
+
+    {:noreply, server}
   end
 
   @impl true

--- a/examples/connection_handler.exs
+++ b/examples/connection_handler.exs
@@ -49,7 +49,7 @@ defmodule Server do
   def init(_args) do
     stream_ids = ["some_stream_id_1", "some_stream_id_2", "some_stream_id_3"]
 
-    {:ok, server} = ExLibSRT.Server.start("0.0.0.0", 12_000, "", -1, stream_ids, self())
+    {:ok, server} = ExLibSRT.Server.start("0.0.0.0", 12_000, accept_mode: {:whitelist, stream_ids}, owner: self())
 
     {:ok, server}
   end

--- a/examples/simple_client_connection.exs
+++ b/examples/simple_client_connection.exs
@@ -11,7 +11,7 @@ defmodule Server do
 
   @impl true
   def init(_args) do
-    {:ok, server} = ExLibSRT.Server.start("0.0.0.0", 12_000)
+    {:ok, server} = ExLibSRT.Server.start("0.0.0.0", 12_000, "", -1, [{"some_stream_id", self()}])
 
     {:ok, %{server: server, packets: 0}}
   end

--- a/examples/simple_client_connection.exs
+++ b/examples/simple_client_connection.exs
@@ -11,7 +11,7 @@ defmodule Server do
 
   @impl true
   def init(_args) do
-    {:ok, server} = ExLibSRT.Server.start("0.0.0.0", 12_000, "", -1, [{"some_stream_id", self()}])
+    {:ok, server} = ExLibSRT.Server.start("0.0.0.0", 12_000, "", -1, ["some_stream_id"])
 
     {:ok, %{server: server, packets: 0}}
   end
@@ -19,6 +19,7 @@ defmodule Server do
   @impl true
   def handle_info({:srt_server_conn, conn_id, stream_id}, state) do
     Logger.info("Connection established with id: #{conn_id} for stream: #{stream_id}")
+    :ok = ExLibSRT.Server.bind_with_process(state.server, conn_id)
 
     {:noreply, state}
   end

--- a/examples/simple_client_connection.exs
+++ b/examples/simple_client_connection.exs
@@ -11,7 +11,7 @@ defmodule Server do
 
   @impl true
   def init(_args) do
-    {:ok, server} = ExLibSRT.Server.start("0.0.0.0", 12_000, "", -1, ["some_stream_id"])
+    {:ok, server} = ExLibSRT.Server.start("0.0.0.0", 12_000, accept_mode: {:whitelist, ["some_stream_id"]})
 
     {:ok, %{server: server, packets: 0}}
   end

--- a/examples/simple_client_connection.exs.exs
+++ b/examples/simple_client_connection.exs.exs
@@ -17,17 +17,6 @@ defmodule Server do
   end
 
   @impl true
-  def handle_info({:srt_server_connect_request, address, stream_id}, state) do
-    Logger.info(
-      "Receiving new connection request with stream id: #{stream_id} from address: #{address}"
-    )
-
-    :ok = ExLibSRT.Server.accept_awaiting_connect_request(state.server)
-
-    {:noreply, state}
-  end
-
-  @impl true
   def handle_info({:srt_server_conn, conn_id, stream_id}, state) do
     Logger.info("Connection established with id: #{conn_id} for stream: #{stream_id}")
 

--- a/lib/ex_libsrt/client.ex
+++ b/lib/ex_libsrt/client.ex
@@ -108,12 +108,8 @@ defmodule ExLibSRT.Client do
   def send_data(payload, _agent) when byte_size(payload) > 1316, do: {:error, :payload_too_large}
 
   def send_data(payload, agent) do
-    if Process.alive?(agent) do
-      client_ref = Agent.get(agent, & &1)
-      ExLibSRT.Native.send_client_data(payload, client_ref)
-    else
-      {:error, "Client is not active"}
-    end
+    client_ref = Agent.get(agent, & &1)
+    ExLibSRT.Native.send_client_data(payload, client_ref)
   end
 
   @doc """
@@ -122,12 +118,8 @@ defmodule ExLibSRT.Client do
   @spec read_socket_stats(t()) ::
           {:ok, ExLibSRT.SocketStats.t()} | {:error, reason :: String.t()}
   def read_socket_stats(agent) do
-    if Process.alive?(agent) do
-      client_ref = Agent.get(agent, & &1)
-      ExLibSRT.Native.read_client_socket_stats(client_ref)
-    else
-      {:error, "Client is not active"}
-    end
+    client_ref = Agent.get(agent, & &1)
+    ExLibSRT.Native.read_client_socket_stats(client_ref)
   end
 
   # Private functions

--- a/lib/ex_libsrt/connection.ex
+++ b/lib/ex_libsrt/connection.ex
@@ -21,11 +21,6 @@ defmodule ExLibSRT.Connection do
     @callback init(t()) :: state()
 
     @doc """
-    Invoked when a connection gets fully established.
-    """
-    @callback handle_connected(connection_id(), stream_id(), state()) :: {:ok, state} | :stop
-
-    @doc """
     Invoked when a connection gets disconnected .
     """
     @callback handle_disconnected(state) :: :ok

--- a/lib/ex_libsrt/connection.ex
+++ b/lib/ex_libsrt/connection.ex
@@ -67,17 +67,6 @@ defmodule ExLibSRT.Connection do
   end
 
   @impl true
-  def handle_info({:srt_server_conn, conn, stream_id}, state) do
-    case state.handler.handle_connected(conn, stream_id, state.handler_state) do
-      {:ok, handler_state} ->
-        {:noreply, %{state | handler_state: handler_state}}
-
-      :stop ->
-        {:stop, :normal, state}
-    end
-  end
-
-  @impl true
   def handle_info({:srt_server_conn_closed, _conn}, state) do
     :ok = state.handler.handle_disconnected(state.handler_state)
 

--- a/lib/ex_libsrt/server.ex
+++ b/lib/ex_libsrt/server.ex
@@ -3,15 +3,16 @@ defmodule ExLibSRT.Server do
   Implementation of the SRT server.
 
   ## API
-  The client API consinsts of the following functions:
+  The server API consists of the following functions:
 
   * `start/2` - starts the server
-  * `start/3` - starts the server with password authentication
+  * `start/5` - starts the server with password authentication, latency and stream ID whitelist
   * `start_link/2` - starts the server and links to current process
-  * `start_link/3` - starts the server with password authentication and links to current process
-  * `start_link/4` - starts the server with password authentication, sets SRT latency and links to current process
+  * `start_link/5` - starts the server with password authentication, latency and stream ID whitelist, links to current process
   * `stop/1` - stops the server
   * `close_server_connection/2` - stops server's connection to given client
+  * `add_stream_id_to_whitelist/3` - adds a stream ID to the server's whitelist at runtime
+  * `remove_stream_id_from_whitelist/2` - removes a stream ID from the server's whitelist at runtime
 
   ## Password Authentication
 
@@ -28,15 +29,17 @@ defmodule ExLibSRT.Server do
 
   ### Accepting connections
   Each SRT connection can carry a `streamid` string which can be used for identifying the stream.
+  The server only accepts connections whose `streamid` is present in the whitelist. For each
+  whitelisted stream ID a receiver process must be provided — this is the process that will
+  receive `t:srt_server_conn/0`, `t:srt_data/0`, and `t:srt_server_conn_closed/0` messages for
+  that stream.
 
-  When user rejects the stream, the server respons with `1403` rejection code (SRT wise). While not being to accept in time
-  results in `1504` (not that the codes respectively are the same of HTTP 403 forbidden and 504 gateway timeout).
+  The whitelist can be supplied up-front via the `allowed_stream_id_with_receiver_list` argument
+  of `start/5` / `start_link/5`, and modified at runtime with `add_stream_id_to_whitelist/3` and
+  `remove_stream_id_from_whitelist/2`.
 
-  > #### Response timeout {: .warning}
-  >
-  > It is very important to answer the connection request as fast as possible.
-  > Due to how `libsrt` works, while the server waits for the response it blocks the receiving thread
-  > and potentially interrupts other ongoing connections.
+  When a client connects with a stream ID that is not on the whitelist, the server responds with
+  rejection code `1403` (analogous to HTTP 403 Forbidden).
   """
 
   use Agent
@@ -65,7 +68,7 @@ defmodule ExLibSRT.Server do
           port :: non_neg_integer(),
           password :: String.t(),
           latency_ms :: integer(),
-          allowed_stream_id_with_receiver_list :: [String.t()]
+          allowed_stream_id_with_receiver_list :: [{String.t(), pid()}]
         ) ::
           {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
   def start_link(
@@ -153,7 +156,14 @@ defmodule ExLibSRT.Server do
     result
   end
 
-  @spec add_stream_id_to_whitelist(t(), String.t()) :: :ok | {:error, reason :: String.t()}
+  @doc """
+  Adds a stream ID to the server's whitelist at runtime.
+
+  The `receiver` process will receive connection and data messages for this stream ID.
+  Defaults to `self()` when not provided.
+  """
+  @spec add_stream_id_to_whitelist(t(), String.t(), pid() | nil) ::
+          :ok | {:error, reason :: String.t()}
   def add_stream_id_to_whitelist(agent, stream_id, receiver \\ nil) do
     receiver = receiver || self()
 
@@ -165,6 +175,11 @@ defmodule ExLibSRT.Server do
     end
   end
 
+  @doc """
+  Removes a stream ID from the server's whitelist at runtime.
+
+  After removal, new connections carrying that stream ID will be rejected.
+  """
   @spec remove_stream_id_from_whitelist(t(), String.t()) :: :ok | {:error, reason :: String.t()}
   def remove_stream_id_from_whitelist(agent, stream_id) do
     if Process.alive?(agent) do

--- a/lib/ex_libsrt/server.ex
+++ b/lib/ex_libsrt/server.ex
@@ -54,8 +54,6 @@ defmodule ExLibSRT.Server do
   1 second the connection is dropped.
 
   The registered receiver will receive `t:srt_data/0` and `t:srt_server_conn_closed/0` messages.
-  When using `bind_with_handler`, the spawned `ExLibSRT.Connection` process also receives
-  `t:srt_server_conn/0` to trigger `c:ExLibSRT.Connection.Handler.handle_connected/3`.
 
   If the owner does not call `bind_with_process/3` or `bind_with_handler/3` within 1 second,
   the connection is dropped and the owner receives `t:srt_server_conn_timeout/0`.

--- a/lib/ex_libsrt/server.ex
+++ b/lib/ex_libsrt/server.ex
@@ -68,7 +68,8 @@ defmodule ExLibSRT.Server do
           port :: non_neg_integer(),
           password :: String.t(),
           latency_ms :: integer(),
-          allowed_stream_id_with_receiver_list :: [{String.t(), pid()}]
+          allowed_stream_id_with_receiver_list :: [{String.t(), pid()}],
+          owner :: pid()
         ) ::
           {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
   def start_link(
@@ -76,8 +77,10 @@ defmodule ExLibSRT.Server do
         port,
         password \\ "",
         latency_ms \\ -1,
-        allowed_stream_id_with_receiver_list \\ []
+        allowed_stream_id_with_receiver_list \\ [],
+        owner \\ nil
       ) do
+    owner = owner || self()
     {stream_ids_whitelist, receivers} = Enum.unzip(allowed_stream_id_with_receiver_list)
 
     with :ok <- validate_password(password),
@@ -88,7 +91,8 @@ defmodule ExLibSRT.Server do
              password,
              latency_ms,
              stream_ids_whitelist,
-             receivers
+             receivers,
+             owner
            ) do
       Agent.start_link(fn -> server_ref end)
     else
@@ -114,7 +118,8 @@ defmodule ExLibSRT.Server do
           port :: non_neg_integer(),
           password :: String.t(),
           latency_ms :: integer(),
-          allowed_stream_id_with_receiver_list :: [{String.t(), pid()}]
+          allowed_stream_id_with_receiver_list :: [{String.t(), pid()}],
+          owner :: pid()
         ) ::
           {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
   def start(
@@ -122,8 +127,10 @@ defmodule ExLibSRT.Server do
         port,
         password \\ "",
         latency_ms \\ -1,
-        allowed_stream_id_with_receiver_list \\ []
+        allowed_stream_id_with_receiver_list \\ [],
+        owner \\ nil
       ) do
+    owner = owner || self()
     {stream_ids_whitelist, receivers} = Enum.unzip(allowed_stream_id_with_receiver_list)
 
     with :ok <- validate_password(password),
@@ -134,7 +141,8 @@ defmodule ExLibSRT.Server do
              password,
              latency_ms,
              stream_ids_whitelist,
-             receivers
+             receivers,
+             owner
            ) do
       Agent.start(fn -> server_ref end, name: {:global, server_ref})
     else

--- a/lib/ex_libsrt/server.ex
+++ b/lib/ex_libsrt/server.ex
@@ -6,9 +6,9 @@ defmodule ExLibSRT.Server do
   The server API consists of the following functions:
 
   * `start/2` - starts the server
-  * `start/5` - starts the server with password authentication, latency and stream ID whitelist
+  * `start/6` - starts the server with password authentication, latency and stream ID whitelist
   * `start_link/2` - starts the server and links to current process
-  * `start_link/5` - starts the server with password authentication, latency and stream ID whitelist, links to current process
+  * `start_link/6` - starts the server with password authentication, latency and stream ID whitelist, links to current process
   * `stop/1` - stops the server
   * `close_server_connection/2` - stops server's connection to given client
   * `add_stream_id_to_whitelist/3` - adds a stream ID to the server's whitelist at runtime
@@ -35,7 +35,7 @@ defmodule ExLibSRT.Server do
   that stream.
 
   The whitelist can be supplied up-front via the `allowed_stream_id_with_receiver_list` argument
-  of `start/5` / `start_link/5`, and modified at runtime with `add_stream_id_to_whitelist/3` and
+  of `start/6` / `start_link/6`, and modified at runtime with `add_stream_id_to_whitelist/3` and
   `remove_stream_id_from_whitelist/2`.
 
   When a client connects with a stream ID that is not on the whitelist, the server responds with
@@ -84,7 +84,7 @@ defmodule ExLibSRT.Server do
           password :: String.t(),
           latency_ms :: integer(),
           allowed_stream_id_with_receiver_list :: [{String.t(), pid()}],
-          owner :: pid()
+          owner :: pid() | nil
         ) ::
           {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
   def start_link(
@@ -149,7 +149,7 @@ defmodule ExLibSRT.Server do
           password :: String.t(),
           latency_ms :: integer(),
           allowed_stream_id_with_receiver_list :: [{String.t(), pid()}],
-          owner :: pid()
+          owner :: pid() | nil
         ) ::
           {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
   def start(

--- a/lib/ex_libsrt/server.ex
+++ b/lib/ex_libsrt/server.ex
@@ -13,6 +13,8 @@ defmodule ExLibSRT.Server do
   * `close_server_connection/2` - stops server's connection to given client
   * `add_stream_id_to_whitelist/3` - adds a stream ID to the server's whitelist at runtime
   * `remove_stream_id_from_whitelist/2` - removes a stream ID from the server's whitelist at runtime
+  * `bind_with_process/2,3` - registers a process as the receiver for a pending connection
+  * `bind_with_handler/3` - spawns a `ExLibSRT.Connection` process and binds it to a pending connection
 
   ## Password Authentication
 
@@ -27,19 +29,33 @@ defmodule ExLibSRT.Server do
   * `t:srt_server_error/0` - server has encountered an error
   * `t:srt_data/0` - server has received new data on a client connection
 
-  ### Accepting connections
+  ### Accepting connections — whitelist mode
   Each SRT connection can carry a `streamid` string which can be used for identifying the stream.
-  The server only accepts connections whose `streamid` is present in the whitelist. For each
+  When `allowed_stream_ids` is non-empty the server operates in **whitelist
+  mode**: only connections whose `streamid` is present in the whitelist are accepted. For each
   whitelisted stream ID a receiver process must be provided — this is the process that will
   receive `t:srt_server_conn/0`, `t:srt_data/0`, and `t:srt_server_conn_closed/0` messages for
   that stream.
 
-  The whitelist can be supplied up-front via the `allowed_stream_id_with_receiver_list` argument
+  The whitelist can be supplied up-front via the `allowed_stream_ids` argument
   of `start/6` / `start_link/6`, and modified at runtime with `add_stream_id_to_whitelist/3` and
   `remove_stream_id_from_whitelist/2`.
 
   When a client connects with a stream ID that is not on the whitelist, the server responds with
   rejection code `1403` (analogous to HTTP 403 Forbidden).
+
+  ### Accepting connections — accept-all mode
+  When `allowed_stream_ids` is `nil` (the default) the server operates in **accept-all mode**:
+  every incoming connection is accepted at the SRT level regardless of its stream ID.
+
+  In both modes the owner process receives a `t:srt_server_conn/0` message for each accepted
+  connection. The owner then has **1 second** to call `bind_with_process/3` or
+  `bind_with_handler/3` to register a receiver for that connection. If no binding happens within
+  1 second the connection is dropped.
+
+  The registered receiver will receive `t:srt_data/0` and `t:srt_server_conn_closed/0` messages.
+  When using `bind_with_handler`, the spawned `ExLibSRT.Connection` process also receives
+  `t:srt_server_conn/0` to trigger `c:ExLibSRT.Connection.Handler.handle_connected/3`.
   """
 
   use Agent
@@ -65,25 +81,23 @@ defmodule ExLibSRT.Server do
 
   ## Stream ID Whitelist
 
-  `allowed_stream_id_with_receiver_list` is a list of `{stream_id, receiver}` pairs that pre-populate
-  the server's whitelist. Each connecting client must present a `streamid` matching one of the listed
-  stream IDs, otherwise it is rejected with code `1403`. The `receiver` pid is the process that will
-  receive `t:srt_server_conn/0`, `t:srt_data/0`, and `t:srt_server_conn_closed/0` messages for that
-  stream. The whitelist can also be modified at runtime with `add_stream_id_to_whitelist/3` and
-  `remove_stream_id_from_whitelist/2`. `ExLibSRT.Connection.start/1` is a convenient way to spawn
-  a dedicated receiver process backed by a `ExLibSRT.Connection.Handler` behaviour.
+  `allowed_stream_ids` is a list of stream ID strings that pre-populate the server's whitelist.
+  Each connecting client must present a `streamid` matching one of the listed IDs, otherwise it
+  is rejected with code `1403`. The whitelist can also be modified at runtime with
+  `add_stream_id_to_whitelist/2` and `remove_stream_id_from_whitelist/2`.
 
   ## Owner
 
-  `owner` is the process that receives `{:srt_server_rejected_client, stream_id}` notifications
-  when a connection attempt is rejected due to an unknown stream ID. Defaults to `self()`.
+  `owner` is the process that receives `t:srt_server_conn/0` notifications for every accepted
+  connection, as well as `{:srt_server_rejected_client, stream_id}` when a connection is rejected.
+  Defaults to `self()`.
   """
   @spec start_link(
           address :: String.t(),
           port :: non_neg_integer(),
           password :: String.t(),
           latency_ms :: integer(),
-          allowed_stream_id_with_receiver_list :: [{String.t(), pid()}],
+          allowed_stream_ids :: [String.t()] | nil,
           owner :: pid() | nil
         ) ::
           {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
@@ -92,11 +106,10 @@ defmodule ExLibSRT.Server do
         port,
         password \\ "",
         latency_ms \\ -1,
-        allowed_stream_id_with_receiver_list \\ [],
+        allowed_stream_ids \\ nil,
         owner \\ nil
       ) do
     owner = owner || self()
-    {stream_ids_whitelist, receivers} = Enum.unzip(allowed_stream_id_with_receiver_list)
 
     with :ok <- validate_password(password),
          {:ok, server_ref} <-
@@ -105,8 +118,7 @@ defmodule ExLibSRT.Server do
              port,
              password,
              latency_ms,
-             stream_ids_whitelist,
-             receivers,
+             allowed_stream_ids || [],
              owner
            ) do
       Agent.start_link(fn -> server_ref end)
@@ -128,18 +140,16 @@ defmodule ExLibSRT.Server do
 
   ## Stream ID Whitelist
 
-  `allowed_stream_id_with_receiver_list` is a list of `{stream_id, receiver}` pairs that pre-populate
-  the server's whitelist. Each connecting client must present a `streamid` matching one of the listed
-  stream IDs, otherwise it is rejected with code `1403`. The `receiver` pid is the process that will
-  receive `t:srt_server_conn/0`, `t:srt_data/0`, and `t:srt_server_conn_closed/0` messages for that
-  stream. The whitelist can also be modified at runtime with `add_stream_id_to_whitelist/3` and
-  `remove_stream_id_from_whitelist/2`. `ExLibSRT.Connection.start/1` is a convenient way to spawn
-  a dedicated receiver process backed by a `ExLibSRT.Connection.Handler` behaviour.
+  `allowed_stream_ids` is a list of stream ID strings that pre-populate the server's whitelist.
+  Each connecting client must present a `streamid` matching one of the listed IDs, otherwise it
+  is rejected with code `1403`. The whitelist can also be modified at runtime with
+  `add_stream_id_to_whitelist/2` and `remove_stream_id_from_whitelist/2`.
 
   ## Owner
 
-  `owner` is the process that receives `{:srt_server_rejected_client, stream_id}` notifications
-  when a connection attempt is rejected due to an unknown stream ID. Defaults to `self()`.
+  `owner` is the process that receives `t:srt_server_conn/0` notifications for every accepted
+  connection, as well as `{:srt_server_rejected_client, stream_id}` when a connection is rejected.
+  Defaults to `self()`.
   """
   @spec start(address :: String.t(), port :: non_neg_integer()) ::
           {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
@@ -148,7 +158,7 @@ defmodule ExLibSRT.Server do
           port :: non_neg_integer(),
           password :: String.t(),
           latency_ms :: integer(),
-          allowed_stream_id_with_receiver_list :: [{String.t(), pid()}],
+          allowed_stream_ids :: [String.t()] | nil,
           owner :: pid() | nil
         ) ::
           {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
@@ -157,11 +167,10 @@ defmodule ExLibSRT.Server do
         port,
         password \\ "",
         latency_ms \\ -1,
-        allowed_stream_id_with_receiver_list \\ [],
+        allowed_stream_ids \\ nil,
         owner \\ nil
       ) do
     owner = owner || self()
-    {stream_ids_whitelist, receivers} = Enum.unzip(allowed_stream_id_with_receiver_list)
 
     with :ok <- validate_password(password),
          {:ok, server_ref} <-
@@ -170,8 +179,7 @@ defmodule ExLibSRT.Server do
              port,
              password,
              latency_ms,
-             stream_ids_whitelist,
-             receivers,
+             allowed_stream_ids || [],
              owner
            ) do
       Agent.start(fn -> server_ref end, name: {:global, server_ref})
@@ -197,19 +205,15 @@ defmodule ExLibSRT.Server do
   @doc """
   Adds a stream ID to the server's whitelist at runtime.
 
-  The `receiver` process will receive `t:srt_server_conn/0`, `t:srt_data/0`, and
-  `t:srt_server_conn_closed/0` messages for this stream ID. Defaults to `self()` when not provided.
-  `ExLibSRT.Connection.start/1` is a convenient way to spawn a dedicated receiver process backed
-  by a `ExLibSRT.Connection.Handler` behaviour.
+  Once added, connections carrying this stream ID will be accepted and the owner will receive
+  `t:srt_server_conn/0`. Call `bind_with_process/3` or `bind_with_handler/3` to register
+  a receiver.
   """
-  @spec add_stream_id_to_whitelist(t(), String.t(), pid() | nil) ::
-          :ok | {:error, reason :: String.t()}
-  def add_stream_id_to_whitelist(agent, stream_id, receiver \\ nil) do
-    receiver = receiver || self()
-
+  @spec add_stream_id_to_whitelist(t(), String.t()) :: :ok | {:error, reason :: String.t()}
+  def add_stream_id_to_whitelist(agent, stream_id) do
     if Process.alive?(agent) do
       server_ref = Agent.get(agent, & &1)
-      ExLibSRT.Native.add_stream_id_to_whitelist(stream_id, receiver, server_ref)
+      ExLibSRT.Native.add_stream_id_to_whitelist(stream_id, server_ref)
     else
       {:error, "Server is not active"}
     end
@@ -227,6 +231,60 @@ defmodule ExLibSRT.Server do
       ExLibSRT.Native.remove_stream_id_from_whitelist(stream_id, server_ref)
     else
       {:error, "Server is not active"}
+    end
+  end
+
+  @doc """
+  Registers the given process (defaults to `self()`) as the receiver for a pending connection.
+
+  Must be called within 1 second of receiving `t:srt_server_conn/0`, otherwise the connection
+  will have been dropped. Returns `{:error, reason}` if the connection ID is not found.
+
+  After a successful bind the receiver will receive `t:srt_data/0` and
+  `t:srt_server_conn_closed/0` messages for the connection.
+  """
+  @spec bind_with_process(t(), connection_id(), pid() | nil) ::
+          :ok | {:error, reason :: String.t()}
+  def bind_with_process(agent, conn_id, receiver \\ nil) do
+    receiver = receiver || self()
+
+    if Process.alive?(agent) do
+      server_ref = Agent.get(agent, & &1)
+
+      case ExLibSRT.Native.bind_with_process(conn_id, receiver, server_ref) do
+        {:ok, _stream_id} -> :ok
+        error -> error
+      end
+    else
+      {:error, "Server is not active"}
+    end
+  end
+
+  @doc """
+  Spawns an `ExLibSRT.Connection` process backed by `handler` and binds it to a pending
+  connection.
+
+  Must be called within 1 second of receiving `t:srt_server_conn/0`. The spawned process
+  receives `t:srt_server_conn/0` to trigger `c:ExLibSRT.Connection.Handler.handle_connected/3`,
+  then `t:srt_data/0` and `t:srt_server_conn_closed/0` for the lifetime of the connection.
+  Returns `{:ok, connection_pid}` on success or `{:error, reason}` if the connection ID is not
+  found or the handler fails to start.
+  """
+  @spec bind_with_handler(ExLibSRT.Connection.Handler.t(), t(), connection_id()) ::
+          {:ok, ExLibSRT.Connection.t()} | {:error, reason :: any()}
+  def bind_with_handler(handler, agent, conn_id) do
+    with true <- Process.alive?(agent),
+         server_ref = Agent.get(agent, & &1),
+         {:ok, conn_process} <- ExLibSRT.Connection.start(handler),
+         {:ok, stream_id} <- ExLibSRT.Native.bind_with_process(conn_id, conn_process, server_ref) do
+      send(conn_process, {:srt_server_conn, conn_id, stream_id})
+      {:ok, conn_process}
+    else
+      false ->
+        {:error, "Server is not active"}
+
+      {:error, _reason} = error ->
+        error
     end
   end
 

--- a/lib/ex_libsrt/server.ex
+++ b/lib/ex_libsrt/server.ex
@@ -11,8 +11,6 @@ defmodule ExLibSRT.Server do
   * `start_link/3` - starts the server with password authentication and links to current process
   * `start_link/4` - starts the server with password authentication, sets SRT latency and links to current process
   * `stop/1` - stops the server
-  * `accept_awaiting_connect_request/1` - accepts next incoming connection
-  * `reject_awaiting_connect_request/1` - rejects next incoming connection
   * `close_server_connection/2` - stops server's connection to given client
 
   ## Password Authentication
@@ -27,15 +25,9 @@ defmodule ExLibSRT.Server do
   * `t:srt_server_conn_closed/0` - a client connection has been closed
   * `t:srt_server_error/0` - server has encountered an error
   * `t:srt_data/0` - server has received new data on a client connection
-  * `t:srt_server_connect_request/0` - server has triggered a new connection request
-    (see `accept_awaiting_connect_request/1` and `reject_awaiting_connect_request/1` for answering the request)
 
   ### Accepting connections
   Each SRT connection can carry a `streamid` string which can be used for identifying the stream.
-
-  To support accepting/rejecting the connection a server sends `t:srt_server_connect_request/0` event.
-  THe process that started the server is then obliged to either call  `accept_awaiting_connect_request/1` or `reject_awaiting_connect_request/1`.
-  Not responding in time will result in server's rejecting the connection.
 
   When user rejects the stream, the server respons with `1403` rejection code (SRT wise). While not being to accept in time
   results in `1504` (not that the codes respectively are the same of HTTP 403 forbidden and 504 gateway timeout).
@@ -57,8 +49,6 @@ defmodule ExLibSRT.Server do
   @type srt_server_conn_closed :: {:srt_server_conn_closed, connection_id()}
   @type srt_server_error :: {:srt_server_error, connection_id(), error :: String.t()}
   @type srt_data :: {:srt_data, connection_id(), data :: binary()}
-  @type srt_server_connect_request ::
-          {:srt_server_connect_request, address :: String.t(), stream_id :: String.t()}
 
   @doc """
   Starts a new SRT server binding to given address and port and links to current process.
@@ -74,12 +64,29 @@ defmodule ExLibSRT.Server do
           address :: String.t(),
           port :: non_neg_integer(),
           password :: String.t(),
-          latency_ms :: integer()
+          latency_ms :: integer(),
+          allowed_stream_id_with_receiver_list :: [String.t()]
         ) ::
           {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
-  def start_link(address, port, password \\ "", latency_ms \\ -1) do
+  def start_link(
+        address,
+        port,
+        password \\ "",
+        latency_ms \\ -1,
+        allowed_stream_id_with_receiver_list \\ []
+      ) do
+    {stream_ids_whitelist, receivers} = Enum.unzip(allowed_stream_id_with_receiver_list)
+
     with :ok <- validate_password(password),
-         {:ok, server_ref} <- ExLibSRT.Native.start_server(address, port, password, latency_ms) do
+         {:ok, server_ref} <-
+           ExLibSRT.Native.start_server(
+             address,
+             port,
+             password,
+             latency_ms,
+             stream_ids_whitelist,
+             receivers
+           ) do
       Agent.start_link(fn -> server_ref end)
     else
       {:error, reason, error_code} -> {:error, reason, error_code}
@@ -99,11 +106,33 @@ defmodule ExLibSRT.Server do
   """
   @spec start(address :: String.t(), port :: non_neg_integer()) ::
           {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
-  @spec start(address :: String.t(), port :: non_neg_integer(), password :: String.t()) ::
+  @spec start(
+          address :: String.t(),
+          port :: non_neg_integer(),
+          password :: String.t(),
+          latency_ms :: integer(),
+          allowed_stream_id_with_receiver_list :: [{String.t(), pid()}]
+        ) ::
           {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
-  def start(address, port, password \\ "") do
+  def start(
+        address,
+        port,
+        password \\ "",
+        latency_ms \\ -1,
+        allowed_stream_id_with_receiver_list \\ []
+      ) do
+    {stream_ids_whitelist, receivers} = Enum.unzip(allowed_stream_id_with_receiver_list)
+
     with :ok <- validate_password(password),
-         {:ok, server_ref} <- ExLibSRT.Native.start_server(address, port, password, -1) do
+         {:ok, server_ref} <-
+           ExLibSRT.Native.start_server(
+             address,
+             port,
+             password,
+             latency_ms,
+             stream_ids_whitelist,
+             receivers
+           ) do
       Agent.start(fn -> server_ref end, name: {:global, server_ref})
     else
       {:error, reason, error_code} -> {:error, reason, error_code}
@@ -124,48 +153,23 @@ defmodule ExLibSRT.Server do
     result
   end
 
-  @doc """
-  Acccepts the currently awaiting connection request.
-  """
-  @spec accept_awaiting_connect_request(t()) :: :ok | {:error, reason :: String.t()}
-  def accept_awaiting_connect_request(agent) do
+  @spec add_stream_id_to_whitelist(t(), String.t()) :: :ok | {:error, reason :: String.t()}
+  def add_stream_id_to_whitelist(agent, stream_id, receiver \\ nil) do
+    receiver = receiver || self()
+
     if Process.alive?(agent) do
       server_ref = Agent.get(agent, & &1)
-      ExLibSRT.Native.accept_awaiting_connect_request(self(), server_ref)
+      ExLibSRT.Native.add_stream_id_to_whitelist(stream_id, receiver, server_ref)
     else
       {:error, "Server is not active"}
     end
   end
 
-  @doc """
-  Acccepts the currently awaiting connection request and starts a separate connection process
-  """
-  @spec accept_awaiting_connect_request_with_handler(ExLibSRT.Connection.Handler.t(), t()) ::
-          {:ok, ExLibSRT.Connection.t()} | {:error, reason :: any()}
-  def accept_awaiting_connect_request_with_handler(handler, agent) do
-    with true <- Process.alive?(agent),
-         server_ref = Agent.get(agent, & &1),
-         {:ok, handler} <- ExLibSRT.Connection.start(handler),
-         :ok <- ExLibSRT.Native.accept_awaiting_connect_request(handler, server_ref) do
-      {:ok, handler}
-    else
-      false ->
-        {:error, "Server is not active"}
-
-      {:error, _reason} = error ->
-        ExLibSRT.Connection.stop(handler)
-        error
-    end
-  end
-
-  @doc """
-  Rejects the currently awaiting connection request.
-  """
-  @spec reject_awaiting_connect_request(t()) :: :ok | {:error, reason :: String.t()}
-  def reject_awaiting_connect_request(agent) do
+  @spec remove_stream_id_from_whitelist(t(), String.t()) :: :ok | {:error, reason :: String.t()}
+  def remove_stream_id_from_whitelist(agent, stream_id) do
     if Process.alive?(agent) do
       server_ref = Agent.get(agent, & &1)
-      ExLibSRT.Native.reject_awaiting_connect_request(server_ref)
+      ExLibSRT.Native.remove_stream_id_from_whitelist(stream_id, server_ref)
     else
       {:error, "Server is not active"}
     end

--- a/lib/ex_libsrt/server.ex
+++ b/lib/ex_libsrt/server.ex
@@ -45,7 +45,7 @@ defmodule ExLibSRT.Server do
   rejection code `1403` (analogous to HTTP 403 Forbidden).
 
   ### Accepting connections — accept-all mode
-  When `allowed_stream_ids` is `nil` (the default) the server operates in **accept-all mode**:
+  When `allowed_stream_ids` is explicitly set to `nil` the server operates in **accept-all mode**:
   every incoming connection is accepted at the SRT level regardless of its stream ID.
 
   In both modes the owner process receives a `t:srt_server_conn/0` message for each accepted
@@ -56,6 +56,9 @@ defmodule ExLibSRT.Server do
   The registered receiver will receive `t:srt_data/0` and `t:srt_server_conn_closed/0` messages.
   When using `bind_with_handler`, the spawned `ExLibSRT.Connection` process also receives
   `t:srt_server_conn/0` to trigger `c:ExLibSRT.Connection.Handler.handle_connected/3`.
+
+  If the owner does not call `bind_with_process/3` or `bind_with_handler/3` within 1 second,
+  the connection is dropped and the owner receives `t:srt_server_conn_timeout/0`.
   """
 
   use Agent
@@ -68,6 +71,8 @@ defmodule ExLibSRT.Server do
   @type srt_server_conn_closed :: {:srt_server_conn_closed, connection_id()}
   @type srt_server_error :: {:srt_server_error, connection_id(), error :: String.t()}
   @type srt_data :: {:srt_data, connection_id(), data :: binary()}
+  @type srt_server_conn_timeout ::
+          {:srt_server_conn_timeout, connection_id(), stream_id :: String.t()}
 
   @doc """
   Starts a new SRT server binding to given address and port and links to current process.
@@ -106,10 +111,11 @@ defmodule ExLibSRT.Server do
         port,
         password \\ "",
         latency_ms \\ -1,
-        allowed_stream_ids \\ nil,
+        allowed_stream_ids \\ [],
         owner \\ nil
       ) do
     owner = owner || self()
+    accept_all = is_nil(allowed_stream_ids)
 
     with :ok <- validate_password(password),
          {:ok, server_ref} <-
@@ -118,6 +124,7 @@ defmodule ExLibSRT.Server do
              port,
              password,
              latency_ms,
+             accept_all,
              allowed_stream_ids || [],
              owner
            ) do
@@ -167,10 +174,11 @@ defmodule ExLibSRT.Server do
         port,
         password \\ "",
         latency_ms \\ -1,
-        allowed_stream_ids \\ nil,
+        allowed_stream_ids \\ [],
         owner \\ nil
       ) do
     owner = owner || self()
+    accept_all = is_nil(allowed_stream_ids)
 
     with :ok <- validate_password(password),
          {:ok, server_ref} <-
@@ -179,6 +187,7 @@ defmodule ExLibSRT.Server do
              port,
              password,
              latency_ms,
+             accept_all,
              allowed_stream_ids || [],
              owner
            ) do
@@ -264,20 +273,15 @@ defmodule ExLibSRT.Server do
   Spawns an `ExLibSRT.Connection` process backed by `handler` and binds it to a pending
   connection.
 
-  Must be called within 1 second of receiving `t:srt_server_conn/0`. The spawned process
-  receives `t:srt_server_conn/0` to trigger `c:ExLibSRT.Connection.Handler.handle_connected/3`,
-  then `t:srt_data/0` and `t:srt_server_conn_closed/0` for the lifetime of the connection.
-  Returns `{:ok, connection_pid}` on success or `{:error, reason}` if the connection ID is not
-  found or the handler fails to start.
+  Must be called within 1 second of receiving `t:srt_server_conn/0`.
   """
-  @spec bind_with_handler(ExLibSRT.Connection.Handler.t(), t(), connection_id()) ::
+  @spec bind_with_handler(t(), connection_id(), ExLibSRT.Connection.Handler.t()) ::
           {:ok, ExLibSRT.Connection.t()} | {:error, reason :: any()}
-  def bind_with_handler(handler, agent, conn_id) do
+  def bind_with_handler(agent, conn_id, handler) do
     with true <- Process.alive?(agent),
          server_ref = Agent.get(agent, & &1),
          {:ok, conn_process} <- ExLibSRT.Connection.start(handler),
-         {:ok, stream_id} <- ExLibSRT.Native.bind_with_process(conn_id, conn_process, server_ref) do
-      send(conn_process, {:srt_server_conn, conn_id, stream_id})
+         {:ok, _stream_id} <- ExLibSRT.Native.bind_with_process(conn_id, conn_process, server_ref) do
       {:ok, conn_process}
     else
       false ->

--- a/lib/ex_libsrt/server.ex
+++ b/lib/ex_libsrt/server.ex
@@ -62,6 +62,21 @@ defmodule ExLibSRT.Server do
 
   If a password is provided, it must be between 10 and 79 characters long according to SRT specification.
   An empty string means no password authentication will be used.
+
+  ## Stream ID Whitelist
+
+  `allowed_stream_id_with_receiver_list` is a list of `{stream_id, receiver}` pairs that pre-populate
+  the server's whitelist. Each connecting client must present a `streamid` matching one of the listed
+  stream IDs, otherwise it is rejected with code `1403`. The `receiver` pid is the process that will
+  receive `t:srt_server_conn/0`, `t:srt_data/0`, and `t:srt_server_conn_closed/0` messages for that
+  stream. The whitelist can also be modified at runtime with `add_stream_id_to_whitelist/3` and
+  `remove_stream_id_from_whitelist/2`. `ExLibSRT.Connection.start/1` is a convenient way to spawn
+  a dedicated receiver process backed by a `ExLibSRT.Connection.Handler` behaviour.
+
+  ## Owner
+
+  `owner` is the process that receives `{:srt_server_rejected_client, stream_id}` notifications
+  when a connection attempt is rejected due to an unknown stream ID. Defaults to `self()`.
   """
   @spec start_link(
           address :: String.t(),
@@ -110,6 +125,21 @@ defmodule ExLibSRT.Server do
 
   If a password is provided, it must be between 10 and 79 characters long according to SRT specification.
   An empty string means no password authentication will be used.
+
+  ## Stream ID Whitelist
+
+  `allowed_stream_id_with_receiver_list` is a list of `{stream_id, receiver}` pairs that pre-populate
+  the server's whitelist. Each connecting client must present a `streamid` matching one of the listed
+  stream IDs, otherwise it is rejected with code `1403`. The `receiver` pid is the process that will
+  receive `t:srt_server_conn/0`, `t:srt_data/0`, and `t:srt_server_conn_closed/0` messages for that
+  stream. The whitelist can also be modified at runtime with `add_stream_id_to_whitelist/3` and
+  `remove_stream_id_from_whitelist/2`. `ExLibSRT.Connection.start/1` is a convenient way to spawn
+  a dedicated receiver process backed by a `ExLibSRT.Connection.Handler` behaviour.
+
+  ## Owner
+
+  `owner` is the process that receives `{:srt_server_rejected_client, stream_id}` notifications
+  when a connection attempt is rejected due to an unknown stream ID. Defaults to `self()`.
   """
   @spec start(address :: String.t(), port :: non_neg_integer()) ::
           {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
@@ -167,8 +197,10 @@ defmodule ExLibSRT.Server do
   @doc """
   Adds a stream ID to the server's whitelist at runtime.
 
-  The `receiver` process will receive connection and data messages for this stream ID.
-  Defaults to `self()` when not provided.
+  The `receiver` process will receive `t:srt_server_conn/0`, `t:srt_data/0`, and
+  `t:srt_server_conn_closed/0` messages for this stream ID. Defaults to `self()` when not provided.
+  `ExLibSRT.Connection.start/1` is a convenient way to spawn a dedicated receiver process backed
+  by a `ExLibSRT.Connection.Handler` behaviour.
   """
   @spec add_stream_id_to_whitelist(t(), String.t(), pid() | nil) ::
           :ok | {:error, reason :: String.t()}

--- a/lib/ex_libsrt/server.ex
+++ b/lib/ex_libsrt/server.ex
@@ -31,7 +31,7 @@ defmodule ExLibSRT.Server do
 
   ### Accepting connections — whitelist mode
   Each SRT connection can carry a `streamid` string which can be used for identifying the stream.
-  When `allowed_stream_ids` is non-empty the server operates in **whitelist
+  When `allowed_stream_ids` is non-nil the server operates in **whitelist
   mode**: only connections whose `streamid` is present in the whitelist are accepted. For each
   whitelisted stream ID a receiver process must be provided — this is the process that will
   receive `t:srt_server_conn/0`, `t:srt_data/0`, and `t:srt_server_conn_closed/0` messages for

--- a/lib/ex_libsrt/server.ex
+++ b/lib/ex_libsrt/server.ex
@@ -242,7 +242,7 @@ defmodule ExLibSRT.Server do
   @spec bind_with_handler(t(), connection_id(), ExLibSRT.Connection.Handler.t()) ::
           {:ok, ExLibSRT.Connection.t()} | {:error, reason :: any()}
   def bind_with_handler(agent, conn_id, handler) do
-    with server_ref = Agent.get(agent, & &1),
+    with server_ref <- Agent.get(agent, & &1),
          {:ok, conn_process} <- ExLibSRT.Connection.start(handler),
          {:ok, _stream_id} <- ExLibSRT.Native.bind_with_process(conn_id, conn_process, server_ref) do
       {:ok, conn_process}
@@ -251,11 +251,6 @@ defmodule ExLibSRT.Server do
         error
     end
   end
-
-  @spec accept_awaiting_connect_request_with_handler(ExLibSRT.Connection.Handler.t(), t()) ::
-          {:ok, ExLibSRT.Connection.t()} | {:error, reason :: any()}
-  def accept_awaiting_connect_request_with_handler(handler, agent),
-    do: bind_with_handler(agent, handler)
 
   @doc """
   Closes the connection to the given client.

--- a/lib/ex_libsrt/server.ex
+++ b/lib/ex_libsrt/server.ex
@@ -190,8 +190,7 @@ defmodule ExLibSRT.Server do
   """
   @spec stop(t()) :: :ok | {:error, reason :: String.t()}
   def stop(agent) do
-    server_ref = Agent.get(agent, & &1)
-    result = ExLibSRT.Native.stop_server(server_ref)
+    result = agent |> get_server() |> ExLibSRT.Native.stop_server()
     Agent.stop(agent)
     result
   end
@@ -205,7 +204,7 @@ defmodule ExLibSRT.Server do
   """
   @spec add_stream_id_to_whitelist(t(), String.t()) :: :ok | {:error, reason :: String.t()}
   def add_stream_id_to_whitelist(agent, stream_id) do
-    server_ref = Agent.get(agent, & &1)
+    server_ref = get_server(agent)
     ExLibSRT.Native.add_stream_id_to_whitelist(stream_id, server_ref)
   end
 
@@ -216,7 +215,7 @@ defmodule ExLibSRT.Server do
   """
   @spec remove_stream_id_from_whitelist(t(), String.t()) :: :ok | {:error, reason :: String.t()}
   def remove_stream_id_from_whitelist(agent, stream_id) do
-    server_ref = Agent.get(agent, & &1)
+    server_ref = get_server(agent)
     ExLibSRT.Native.remove_stream_id_from_whitelist(stream_id, server_ref)
   end
 
@@ -233,8 +232,7 @@ defmodule ExLibSRT.Server do
           :ok | {:error, reason :: String.t()}
   def bind_with_process(agent, conn_id, receiver \\ nil) do
     receiver = receiver || self()
-
-    server_ref = Agent.get(agent, & &1)
+    server_ref = get_server(agent)
 
     case ExLibSRT.Native.bind_with_process(conn_id, receiver, server_ref) do
       {:ok, _stream_id} -> :ok
@@ -251,9 +249,9 @@ defmodule ExLibSRT.Server do
   @spec bind_with_handler(t(), connection_id(), ExLibSRT.Connection.Handler.t()) ::
           {:ok, ExLibSRT.Connection.t()} | {:error, reason :: any()}
   def bind_with_handler(agent, conn_id, handler) do
-    with server_ref <- Agent.get(agent, & &1),
-         {:ok, conn_process} <- ExLibSRT.Connection.start(handler),
-         {:ok, _stream_id} <- ExLibSRT.Native.bind_with_process(conn_id, conn_process, server_ref) do
+    with {:ok, conn_process} <- ExLibSRT.Connection.start(handler),
+         {:ok, _stream_id} <-
+           ExLibSRT.Native.bind_with_process(conn_id, conn_process, get_server(agent)) do
       {:ok, conn_process}
     else
       {:error, _reason} = error ->
@@ -266,7 +264,7 @@ defmodule ExLibSRT.Server do
   """
   @spec close_server_connection(connection_id(), t()) :: :ok | {:error, reason :: String.t()}
   def close_server_connection(connection_id, agent) do
-    server_ref = Agent.get(agent, & &1)
+    server_ref = get_server(agent)
     ExLibSRT.Native.close_server_connection(connection_id, server_ref)
   end
 
@@ -276,7 +274,7 @@ defmodule ExLibSRT.Server do
   @spec read_socket_stats(connection_id(), t()) ::
           {:ok, ExLibSRT.SocketStats.t()} | {:error, reason :: String.t()}
   def read_socket_stats(connection_id, agent) do
-    server_ref = Agent.get(agent, & &1)
+    server_ref = get_server(agent)
     ExLibSRT.Native.read_server_socket_stats(connection_id, server_ref)
   end
 
@@ -301,4 +299,9 @@ defmodule ExLibSRT.Server do
   end
 
   defp validate_password(_password), do: {:error, "Password must be a string"}
+
+  @spec get_server(t()) :: reference()
+  defp get_server(agent) do
+    Agent.get(agent, & &1)
+  end
 end

--- a/lib/ex_libsrt/server.ex
+++ b/lib/ex_libsrt/server.ex
@@ -13,7 +13,8 @@ defmodule ExLibSRT.Server do
     notifications (`t:srt_server_conn_closed/0`) for a specific connection. Can be bound via
     `bind_with_process/3` or `bind_with_handler/3`.
 
-  ## Accepting connections — whitelist mode
+  ## Accepting connections
+  ### whitelist mode
   Each SRT connection can carry a `streamid` string which can be used for identifying the stream.
   When `accept_mode: :whitelist` or `accept_mode: {:whitelist, ids}` the server operates in
   **whitelist mode**: only connections whose `streamid` is present in the whitelist are accepted.
@@ -25,7 +26,7 @@ defmodule ExLibSRT.Server do
   When a client connects with a stream ID that is not on the whitelist, the server responds with
   rejection code `1403` (analogous to HTTP 403 Forbidden).
 
-  ## Accepting connections — accept-all mode
+  ### accept-all mode
   When `accept_mode: :accept_all` the server operates in **accept-all mode**:
   every incoming connection is accepted at the SRT level regardless of its stream ID.
 
@@ -74,10 +75,9 @@ defmodule ExLibSRT.Server do
 
   * `:password` - SRT passphrase for authentication. Must be between 10 and 79 characters long
     according to SRT specification. Empty string (default) means no password authentication.
-  * `:latency_ms` - SRT latency in milliseconds. Defaults to `-1`.
+  * `:latency_ms` - SRT latency in milliseconds, used to set [`SRTO_LATENCY` flag](https://github.com/Haivision/srt/blob/master/docs/API/API-socket-options.md#srto_latency). Defaults to `-1` (meaning that `SRTO_LATENCY` flag is not set).
   * `:accept_mode` - Controls how the server accepts connections. See
-    [whitelist mode](#module-accepting-connections-whitelist-mode) and
-    [accept-all mode](#module-accepting-connections-accept-all-mode) for details.
+    [whitelist mode](#module-accepting-connections) for details.
     Valid values are:
     * `:accept_all` - Accept all connections regardless of stream ID.
     * `:whitelist` - Whitelist mode with an empty initial whitelist.

--- a/lib/ex_libsrt/server.ex
+++ b/lib/ex_libsrt/server.ex
@@ -2,13 +2,21 @@ defmodule ExLibSRT.Server do
   @moduledoc """
   Implementation of the SRT server.
 
+  ## Glossary
+
+  * **Stream ID** — An optional string identifier carried by each SRT connection. Clients can specify
+    a stream ID when connecting, and the server can use it to identify and route connections.
+  * **Owner** — The process that receives notifications about new connections (`t:srt_server_conn/0`),
+    rejected connections (`{:srt_server_rejected_client, stream_id}`), and server errors
+    (`t:srt_server_error/0`).
+  * **Receiver** — The process that receives data messages (`t:srt_data/0`) and disconnection
+    notifications (`t:srt_server_conn_closed/0`) for a specific connection. Can be bound via
+    `bind_with_process/3` or `bind_with_handler/3`.
+
   ## Accepting connections — whitelist mode
   Each SRT connection can carry a `streamid` string which can be used for identifying the stream.
   When `accept_mode: :whitelist` or `accept_mode: {:whitelist, ids}` the server operates in
   **whitelist mode**: only connections whose `streamid` is present in the whitelist are accepted.
-  For each whitelisted stream ID a receiver process must be provided — this is the process that will
-  receive `t:srt_server_conn/0`, `t:srt_data/0`, and `t:srt_server_conn_closed/0` messages for
-  that stream.
 
   The whitelist can be supplied up-front via the `:accept_mode` option of `start/3` / `start_link/3`
   (e.g., `accept_mode: {:whitelist, stream_ids}`), and modified at runtime with
@@ -24,12 +32,9 @@ defmodule ExLibSRT.Server do
   In both modes the owner process receives a `t:srt_server_conn/0` message for each accepted
   connection. The owner then has **1 second** to call `bind_with_process/3` or
   `bind_with_handler/3` to register a receiver for that connection. If no binding happens within
-  1 second the connection is dropped.
+  1 second the connection is dropped and the owner receives `t:srt_server_conn_timeout/0`.
 
   The registered receiver will receive `t:srt_data/0` and `t:srt_server_conn_closed/0` messages.
-
-  If the owner does not call `bind_with_process/3` or `bind_with_handler/3` within 1 second,
-  the connection is dropped and the owner receives `t:srt_server_conn_timeout/0`.
 
   ## Password Authentication
 
@@ -70,12 +75,14 @@ defmodule ExLibSRT.Server do
   * `:password` - SRT passphrase for authentication. Must be between 10 and 79 characters long
     according to SRT specification. Empty string (default) means no password authentication.
   * `:latency_ms` - SRT latency in milliseconds. Defaults to `-1`.
-  * `:accept_mode` - Controls how the server accepts connections. Valid values are:
+  * `:accept_mode` - Controls how the server accepts connections. See
+    [whitelist mode](#accepting-connections-whitelist-mode) and
+    [accept-all mode](#accepting-connections-accept-all-mode) for details.
+    Valid values are:
     * `:accept_all` - Accept all connections regardless of stream ID.
     * `:whitelist` - Whitelist mode with an empty initial whitelist.
     * `{:whitelist, stream_ids}` - Whitelist mode with pre-populated stream IDs.
-    Defaults to `:whitelist`. In whitelist mode, the whitelist can be modified at runtime with
-    `add_stream_id_to_whitelist/2` and `remove_stream_id_from_whitelist/2`.
+    Defaults to `:whitelist`.
   * `:owner` - The process that receives `t:srt_server_conn/0` notifications for every accepted
     connection, as well as `{:srt_server_rejected_client, stream_id}` when a connection is rejected.
     Defaults to `self()`.
@@ -127,12 +134,14 @@ defmodule ExLibSRT.Server do
   * `:password` - SRT passphrase for authentication. Must be between 10 and 79 characters long
     according to SRT specification. Empty string (default) means no password authentication.
   * `:latency_ms` - SRT latency in milliseconds. Defaults to `-1`.
-  * `:accept_mode` - Controls how the server accepts connections. Valid values are:
+  * `:accept_mode` - Controls how the server accepts connections. See
+    [whitelist mode](#accepting-connections-whitelist-mode) and
+    [accept-all mode](#accepting-connections-accept-all-mode) for details.
+    Valid values are:
     * `:accept_all` - Accept all connections regardless of stream ID.
     * `:whitelist` - Whitelist mode with an empty initial whitelist.
     * `{:whitelist, stream_ids}` - Whitelist mode with pre-populated stream IDs.
-    Defaults to `:whitelist`. In whitelist mode, the whitelist can be modified at runtime with
-    `add_stream_id_to_whitelist/2` and `remove_stream_id_from_whitelist/2`.
+    Defaults to `:whitelist`.
   * `:owner` - The process that receives `t:srt_server_conn/0` notifications for every accepted
     connection, as well as `{:srt_server_rejected_client, stream_id}` when a connection is rejected.
     Defaults to `self()`.

--- a/lib/ex_libsrt/server.ex
+++ b/lib/ex_libsrt/server.ex
@@ -76,8 +76,8 @@ defmodule ExLibSRT.Server do
     according to SRT specification. Empty string (default) means no password authentication.
   * `:latency_ms` - SRT latency in milliseconds. Defaults to `-1`.
   * `:accept_mode` - Controls how the server accepts connections. See
-    [whitelist mode](#accepting-connections-whitelist-mode) and
-    [accept-all mode](#accepting-connections-accept-all-mode) for details.
+    [whitelist mode](#module-accepting-connections-whitelist-mode) and
+    [accept-all mode](#module-accepting-connections-accept-all-mode) for details.
     Valid values are:
     * `:accept_all` - Accept all connections regardless of stream ID.
     * `:whitelist` - Whitelist mode with an empty initial whitelist.
@@ -135,8 +135,8 @@ defmodule ExLibSRT.Server do
     according to SRT specification. Empty string (default) means no password authentication.
   * `:latency_ms` - SRT latency in milliseconds. Defaults to `-1`.
   * `:accept_mode` - Controls how the server accepts connections. See
-    [whitelist mode](#accepting-connections-whitelist-mode) and
-    [accept-all mode](#accepting-connections-accept-all-mode) for details.
+    [whitelist mode](#module-accepting-connections-whitelist-mode) and
+    [accept-all mode](#module-accepting-connections-accept-all-mode) for details.
     Valid values are:
     * `:accept_all` - Accept all connections regardless of stream ID.
     * `:whitelist` - Whitelist mode with an empty initial whitelist.

--- a/lib/ex_libsrt/server.ex
+++ b/lib/ex_libsrt/server.ex
@@ -2,19 +2,34 @@ defmodule ExLibSRT.Server do
   @moduledoc """
   Implementation of the SRT server.
 
-  ## API
-  The server API consists of the following functions:
+  ## Accepting connections — whitelist mode
+  Each SRT connection can carry a `streamid` string which can be used for identifying the stream.
+  When `accept_mode: :whitelist` or `accept_mode: {:whitelist, ids}` the server operates in
+  **whitelist mode**: only connections whose `streamid` is present in the whitelist are accepted.
+  For each whitelisted stream ID a receiver process must be provided — this is the process that will
+  receive `t:srt_server_conn/0`, `t:srt_data/0`, and `t:srt_server_conn_closed/0` messages for
+  that stream.
 
-  * `start/2` - starts the server
-  * `start/6` - starts the server with password authentication, latency and stream ID whitelist
-  * `start_link/2` - starts the server and links to current process
-  * `start_link/6` - starts the server with password authentication, latency and stream ID whitelist, links to current process
-  * `stop/1` - stops the server
-  * `close_server_connection/2` - stops server's connection to given client
-  * `add_stream_id_to_whitelist/3` - adds a stream ID to the server's whitelist at runtime
-  * `remove_stream_id_from_whitelist/2` - removes a stream ID from the server's whitelist at runtime
-  * `bind_with_process/2,3` - registers a process as the receiver for a pending connection
-  * `bind_with_handler/3` - spawns a `ExLibSRT.Connection` process and binds it to a pending connection
+  The whitelist can be supplied up-front via the `:accept_mode` option of `start/3` / `start_link/3`
+  (e.g., `accept_mode: {:whitelist, stream_ids}`), and modified at runtime with
+  `add_stream_id_to_whitelist/2` and `remove_stream_id_from_whitelist/2`.
+
+  When a client connects with a stream ID that is not on the whitelist, the server responds with
+  rejection code `1403` (analogous to HTTP 403 Forbidden).
+
+  ## Accepting connections — accept-all mode
+  When `accept_mode: :accept_all` the server operates in **accept-all mode**:
+  every incoming connection is accepted at the SRT level regardless of its stream ID.
+
+  In both modes the owner process receives a `t:srt_server_conn/0` message for each accepted
+  connection. The owner then has **1 second** to call `bind_with_process/3` or
+  `bind_with_handler/3` to register a receiver for that connection. If no binding happens within
+  1 second the connection is dropped.
+
+  The registered receiver will receive `t:srt_data/0` and `t:srt_server_conn_closed/0` messages.
+
+  If the owner does not call `bind_with_process/3` or `bind_with_handler/3` within 1 second,
+  the connection is dropped and the owner receives `t:srt_server_conn_timeout/0`.
 
   ## Password Authentication
 
@@ -28,35 +43,6 @@ defmodule ExLibSRT.Server do
   * `t:srt_server_conn_closed/0` - a client connection has been closed
   * `t:srt_server_error/0` - server has encountered an error
   * `t:srt_data/0` - server has received new data on a client connection
-
-  ### Accepting connections — whitelist mode
-  Each SRT connection can carry a `streamid` string which can be used for identifying the stream.
-  When `allowed_stream_ids` is non-nil the server operates in **whitelist
-  mode**: only connections whose `streamid` is present in the whitelist are accepted. For each
-  whitelisted stream ID a receiver process must be provided — this is the process that will
-  receive `t:srt_server_conn/0`, `t:srt_data/0`, and `t:srt_server_conn_closed/0` messages for
-  that stream.
-
-  The whitelist can be supplied up-front via the `allowed_stream_ids` argument
-  of `start/6` / `start_link/6`, and modified at runtime with `add_stream_id_to_whitelist/3` and
-  `remove_stream_id_from_whitelist/2`.
-
-  When a client connects with a stream ID that is not on the whitelist, the server responds with
-  rejection code `1403` (analogous to HTTP 403 Forbidden).
-
-  ### Accepting connections — accept-all mode
-  When `allowed_stream_ids` is explicitly set to `nil` the server operates in **accept-all mode**:
-  every incoming connection is accepted at the SRT level regardless of its stream ID.
-
-  In both modes the owner process receives a `t:srt_server_conn/0` message for each accepted
-  connection. The owner then has **1 second** to call `bind_with_process/3` or
-  `bind_with_handler/3` to register a receiver for that connection. If no binding happens within
-  1 second the connection is dropped.
-
-  The registered receiver will receive `t:srt_data/0` and `t:srt_server_conn_closed/0` messages.
-
-  If the owner does not call `bind_with_process/3` or `bind_with_handler/3` within 1 second,
-  the connection is dropped and the owner receives `t:srt_server_conn_timeout/0`.
   """
 
   use Agent
@@ -64,6 +50,8 @@ defmodule ExLibSRT.Server do
   @type t :: pid()
 
   @type connection_id :: non_neg_integer()
+
+  @type accept_mode :: :accept_all | :whitelist | {:whitelist, [String.t()]}
 
   @type srt_server_conn :: {:srt_server_conn, connection_id(), stream_id :: String.t()}
   @type srt_server_conn_closed :: {:srt_server_conn_closed, connection_id()}
@@ -77,43 +65,39 @@ defmodule ExLibSRT.Server do
 
   One may usually want to bind to `0.0.0.0` address.
 
-  ## Password Requirements
+  ## Options
 
-  If a password is provided, it must be between 10 and 79 characters long according to SRT specification.
-  An empty string means no password authentication will be used.
-
-  ## Stream ID Whitelist
-
-  `allowed_stream_ids` is a list of stream ID strings that pre-populate the server's whitelist.
-  Each connecting client must present a `streamid` matching one of the listed IDs, otherwise it
-  is rejected with code `1403`. The whitelist can also be modified at runtime with
-  `add_stream_id_to_whitelist/2` and `remove_stream_id_from_whitelist/2`.
-
-  ## Owner
-
-  `owner` is the process that receives `t:srt_server_conn/0` notifications for every accepted
-  connection, as well as `{:srt_server_rejected_client, stream_id}` when a connection is rejected.
-  Defaults to `self()`.
+  * `:password` - SRT passphrase for authentication. Must be between 10 and 79 characters long
+    according to SRT specification. Empty string (default) means no password authentication.
+  * `:latency_ms` - SRT latency in milliseconds. Defaults to `-1`.
+  * `:accept_mode` - Controls how the server accepts connections. Valid values are:
+    * `:accept_all` - Accept all connections regardless of stream ID.
+    * `:whitelist` - Whitelist mode with an empty initial whitelist.
+    * `{:whitelist, stream_ids}` - Whitelist mode with pre-populated stream IDs.
+    Defaults to `:whitelist`. In whitelist mode, the whitelist can be modified at runtime with
+    `add_stream_id_to_whitelist/2` and `remove_stream_id_from_whitelist/2`.
+  * `:owner` - The process that receives `t:srt_server_conn/0` notifications for every accepted
+    connection, as well as `{:srt_server_rejected_client, stream_id}` when a connection is rejected.
+    Defaults to `self()`.
   """
   @spec start_link(
           address :: String.t(),
           port :: non_neg_integer(),
-          password :: String.t(),
-          latency_ms :: integer(),
-          allowed_stream_ids :: [String.t()] | nil,
-          owner :: pid() | nil
+          opts :: keyword()
         ) ::
           {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
-  def start_link(
-        address,
-        port,
-        password \\ "",
-        latency_ms \\ -1,
-        allowed_stream_ids \\ [],
-        owner \\ nil
-      ) do
-    owner = owner || self()
-    accept_all = is_nil(allowed_stream_ids)
+  def start_link(address, port, opts \\ []) do
+    password = Keyword.get(opts, :password, "")
+    latency_ms = Keyword.get(opts, :latency_ms, -1)
+    accept_mode = Keyword.get(opts, :accept_mode, :whitelist)
+    owner = Keyword.get(opts, :owner) || self()
+
+    {accept_all, allowed_stream_ids} =
+      case accept_mode do
+        :accept_all -> {true, []}
+        :whitelist -> {false, []}
+        {:whitelist, ids} -> {false, ids}
+      end
 
     with :ok <- validate_password(password),
          {:ok, server_ref} <-
@@ -138,45 +122,39 @@ defmodule ExLibSRT.Server do
 
   One may usually want to bind to `0.0.0.0` address.
 
-  ## Password Requirements
+  ## Options
 
-  If a password is provided, it must be between 10 and 79 characters long according to SRT specification.
-  An empty string means no password authentication will be used.
-
-  ## Stream ID Whitelist
-
-  `allowed_stream_ids` is a list of stream ID strings that pre-populate the server's whitelist.
-  Each connecting client must present a `streamid` matching one of the listed IDs, otherwise it
-  is rejected with code `1403`. The whitelist can also be modified at runtime with
-  `add_stream_id_to_whitelist/2` and `remove_stream_id_from_whitelist/2`.
-
-  ## Owner
-
-  `owner` is the process that receives `t:srt_server_conn/0` notifications for every accepted
-  connection, as well as `{:srt_server_rejected_client, stream_id}` when a connection is rejected.
-  Defaults to `self()`.
+  * `:password` - SRT passphrase for authentication. Must be between 10 and 79 characters long
+    according to SRT specification. Empty string (default) means no password authentication.
+  * `:latency_ms` - SRT latency in milliseconds. Defaults to `-1`.
+  * `:accept_mode` - Controls how the server accepts connections. Valid values are:
+    * `:accept_all` - Accept all connections regardless of stream ID.
+    * `:whitelist` - Whitelist mode with an empty initial whitelist.
+    * `{:whitelist, stream_ids}` - Whitelist mode with pre-populated stream IDs.
+    Defaults to `:whitelist`. In whitelist mode, the whitelist can be modified at runtime with
+    `add_stream_id_to_whitelist/2` and `remove_stream_id_from_whitelist/2`.
+  * `:owner` - The process that receives `t:srt_server_conn/0` notifications for every accepted
+    connection, as well as `{:srt_server_rejected_client, stream_id}` when a connection is rejected.
+    Defaults to `self()`.
   """
-  @spec start(address :: String.t(), port :: non_neg_integer()) ::
-          {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
   @spec start(
           address :: String.t(),
           port :: non_neg_integer(),
-          password :: String.t(),
-          latency_ms :: integer(),
-          allowed_stream_ids :: [String.t()] | nil,
-          owner :: pid() | nil
+          opts :: keyword()
         ) ::
           {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
-  def start(
-        address,
-        port,
-        password \\ "",
-        latency_ms \\ -1,
-        allowed_stream_ids \\ [],
-        owner \\ nil
-      ) do
-    owner = owner || self()
-    accept_all = is_nil(allowed_stream_ids)
+  def start(address, port, opts \\ []) do
+    password = Keyword.get(opts, :password, "")
+    latency_ms = Keyword.get(opts, :latency_ms, -1)
+    accept_mode = Keyword.get(opts, :accept_mode, :whitelist)
+    owner = Keyword.get(opts, :owner) || self()
+
+    {accept_all, allowed_stream_ids} =
+      case accept_mode do
+        :accept_all -> {true, []}
+        :whitelist -> {false, []}
+        {:whitelist, ids} -> {false, ids}
+      end
 
     with :ok <- validate_password(password),
          {:ok, server_ref} <-
@@ -218,12 +196,8 @@ defmodule ExLibSRT.Server do
   """
   @spec add_stream_id_to_whitelist(t(), String.t()) :: :ok | {:error, reason :: String.t()}
   def add_stream_id_to_whitelist(agent, stream_id) do
-    if Process.alive?(agent) do
-      server_ref = Agent.get(agent, & &1)
-      ExLibSRT.Native.add_stream_id_to_whitelist(stream_id, server_ref)
-    else
-      {:error, "Server is not active"}
-    end
+    server_ref = Agent.get(agent, & &1)
+    ExLibSRT.Native.add_stream_id_to_whitelist(stream_id, server_ref)
   end
 
   @doc """
@@ -233,12 +207,8 @@ defmodule ExLibSRT.Server do
   """
   @spec remove_stream_id_from_whitelist(t(), String.t()) :: :ok | {:error, reason :: String.t()}
   def remove_stream_id_from_whitelist(agent, stream_id) do
-    if Process.alive?(agent) do
-      server_ref = Agent.get(agent, & &1)
-      ExLibSRT.Native.remove_stream_id_from_whitelist(stream_id, server_ref)
-    else
-      {:error, "Server is not active"}
-    end
+    server_ref = Agent.get(agent, & &1)
+    ExLibSRT.Native.remove_stream_id_from_whitelist(stream_id, server_ref)
   end
 
   @doc """
@@ -255,15 +225,11 @@ defmodule ExLibSRT.Server do
   def bind_with_process(agent, conn_id, receiver \\ nil) do
     receiver = receiver || self()
 
-    if Process.alive?(agent) do
-      server_ref = Agent.get(agent, & &1)
+    server_ref = Agent.get(agent, & &1)
 
-      case ExLibSRT.Native.bind_with_process(conn_id, receiver, server_ref) do
-        {:ok, _stream_id} -> :ok
-        error -> error
-      end
-    else
-      {:error, "Server is not active"}
+    case ExLibSRT.Native.bind_with_process(conn_id, receiver, server_ref) do
+      {:ok, _stream_id} -> :ok
+      error -> error
     end
   end
 
@@ -276,31 +242,28 @@ defmodule ExLibSRT.Server do
   @spec bind_with_handler(t(), connection_id(), ExLibSRT.Connection.Handler.t()) ::
           {:ok, ExLibSRT.Connection.t()} | {:error, reason :: any()}
   def bind_with_handler(agent, conn_id, handler) do
-    with true <- Process.alive?(agent),
-         server_ref = Agent.get(agent, & &1),
+    with server_ref = Agent.get(agent, & &1),
          {:ok, conn_process} <- ExLibSRT.Connection.start(handler),
          {:ok, _stream_id} <- ExLibSRT.Native.bind_with_process(conn_id, conn_process, server_ref) do
       {:ok, conn_process}
     else
-      false ->
-        {:error, "Server is not active"}
-
       {:error, _reason} = error ->
         error
     end
   end
+
+  @spec accept_awaiting_connect_request_with_handler(ExLibSRT.Connection.Handler.t(), t()) ::
+          {:ok, ExLibSRT.Connection.t()} | {:error, reason :: any()}
+  def accept_awaiting_connect_request_with_handler(handler, agent),
+    do: bind_with_handler(agent, handler)
 
   @doc """
   Closes the connection to the given client.
   """
   @spec close_server_connection(connection_id(), t()) :: :ok | {:error, reason :: String.t()}
   def close_server_connection(connection_id, agent) do
-    if Process.alive?(agent) do
-      server_ref = Agent.get(agent, & &1)
-      ExLibSRT.Native.close_server_connection(connection_id, server_ref)
-    else
-      {:error, "Server is not active"}
-    end
+    server_ref = Agent.get(agent, & &1)
+    ExLibSRT.Native.close_server_connection(connection_id, server_ref)
   end
 
   @doc """
@@ -309,12 +272,8 @@ defmodule ExLibSRT.Server do
   @spec read_socket_stats(connection_id(), t()) ::
           {:ok, ExLibSRT.SocketStats.t()} | {:error, reason :: String.t()}
   def read_socket_stats(connection_id, agent) do
-    if Process.alive?(agent) do
-      server_ref = Agent.get(agent, & &1)
-      ExLibSRT.Native.read_server_socket_stats(connection_id, server_ref)
-    else
-      {:error, "Server is not active"}
-    end
+    server_ref = Agent.get(agent, & &1)
+    ExLibSRT.Native.read_server_socket_stats(connection_id, server_ref)
   end
 
   # Private functions

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExLibSRT.MixProject do
   use Mix.Project
 
-  @version "0.1.7"
+  @version "0.2.0"
   @github_url "https://github.com/membraneframework/ex_libsrt"
 
   def project do
@@ -35,7 +35,7 @@ defmodule ExLibSRT.MixProject do
         "GitHub" => @github_url,
         "Membrane Framework Homepage" => "https://membrane.stream"
       },
-      files: ["lib", "mix.exs", "README*", "LICENSE*", ".formatter.exs", "bundlex.exs", "c_src"],
+      files: ["lib", "mix.exs", "README*", "LICENSE*", ".formatter.exs", "bundlex.exs", "c_src", "MIGRATION_v0_2.md"],
       exclude_patterns: [~r"c_src/.*/_generated.*"]
     ]
   end
@@ -43,7 +43,7 @@ defmodule ExLibSRT.MixProject do
   defp docs do
     [
       main: "readme",
-      extras: ["README.md", "LICENSE"],
+      extras: ["README.md", "LICENSE", "MIGRATION_v0_2.md"],
       formatters: ["html"],
       source_ref: "v#{@version}",
       nest_modules_by_prefix: [ExLibSRT]

--- a/mix.exs
+++ b/mix.exs
@@ -42,8 +42,7 @@ defmodule ExLibSRT.MixProject do
         "LICENSE*",
         ".formatter.exs",
         "bundlex.exs",
-        "c_src",
-        "MIGRATION_v0_2.md"
+        "c_src"
       ],
       exclude_patterns: [~r"c_src/.*/_generated.*"]
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,16 @@ defmodule ExLibSRT.MixProject do
         "GitHub" => @github_url,
         "Membrane Framework Homepage" => "https://membrane.stream"
       },
-      files: ["lib", "mix.exs", "README*", "LICENSE*", ".formatter.exs", "bundlex.exs", "c_src", "MIGRATION_v0_2.md"],
+      files: [
+        "lib",
+        "mix.exs",
+        "README*",
+        "LICENSE*",
+        ".formatter.exs",
+        "bundlex.exs",
+        "c_src",
+        "MIGRATION_v0_2.md"
+      ],
       exclude_patterns: [~r"c_src/.*/_generated.*"]
     ]
   end

--- a/test/ex_libsrt/client_server_coop_test.exs
+++ b/test/ex_libsrt/client_server_coop_test.exs
@@ -10,12 +10,9 @@ defmodule ExLibSRT.ClientServerCoopTest do
 
     Task.start(fn ->
       assert {:ok, server} = Server.start("127.0.0.1", ctx.srt_port)
+      Server.add_stream_id_to_whitelist(server, "some_stream_id")
 
       send(parent, :running)
-
-      assert_receive {:srt_server_connect_request, _address, "some_stream_id"}
-
-      Server.accept_awaiting_connect_request(server)
 
       assert_receive {:srt_server_conn, conn_id, _stream_id}, 1000
 
@@ -46,14 +43,11 @@ defmodule ExLibSRT.ClientServerCoopTest do
 
     Task.start(fn ->
       assert {:ok, server} = Server.start("127.0.0.1", ctx.srt_port)
+      Server.add_stream_id_to_whitelist(server, "allowed_stream")
 
       send(parent, :running)
 
-      assert_receive {:srt_server_connect_request, _address, "some_stream_id"}
-
-      Server.reject_awaiting_connect_request(server)
-
-      Process.sleep(100)
+      Process.sleep(2_000)
 
       Server.stop(server)
 
@@ -68,31 +62,6 @@ defmodule ExLibSRT.ClientServerCoopTest do
     assert_receive :stopped, 2_000
   end
 
-  test "reject client when timeing out the request awaiting time", ctx do
-    parent = self()
-
-    Task.start(fn ->
-      assert {:ok, server} = Server.start("127.0.0.1", ctx.srt_port)
-
-      send(parent, :running)
-
-      Process.sleep(1_000)
-
-      Process.sleep(100)
-
-      Server.stop(server)
-
-      send(parent, :stopped)
-    end)
-
-    assert_receive :running, 500
-
-    assert {:error, "Stream rejected by server", 504} =
-             Client.start("127.0.0.1", ctx.srt_port, "some_stream_id")
-
-    assert_receive :stopped, 2_000
-  end
-
   # Password authentication tests
   describe "client-server password authentication" do
     test "successful connection with matching passwords", ctx do
@@ -101,10 +70,8 @@ defmodule ExLibSRT.ClientServerCoopTest do
 
       Task.start(fn ->
         assert {:ok, server} = Server.start("127.0.0.1", ctx.srt_port, password)
+        Server.add_stream_id_to_whitelist(server, "auth_stream")
         send(parent, :server_running)
-
-        assert_receive {:srt_server_connect_request, _address, "auth_stream"}
-        Server.accept_awaiting_connect_request(server)
 
         assert_receive {:srt_server_conn, _conn_id, _stream_id}, 1_000
 
@@ -131,12 +98,10 @@ defmodule ExLibSRT.ClientServerCoopTest do
         assert {:ok, server} = Server.start("127.0.0.1", ctx.srt_port, server_password)
         send(parent, :server_running)
 
-        # Server may receive connect request but should reject due to password mismatch
         receive do
-          {:srt_server_connect_request, _address, "auth_stream"} ->
-            Server.accept_awaiting_connect_request(server)
+          {:srt_server_conn, _address, "auth_stream"} -> :ok
         after
-          2_000 -> :timeout
+          2_000 -> :ok
         end
 
         Server.stop(server)
@@ -162,10 +127,9 @@ defmodule ExLibSRT.ClientServerCoopTest do
         send(parent, :server_running)
 
         receive do
-          {:srt_server_connect_request, _address, "auth_stream"} ->
-            Server.accept_awaiting_connect_request(server)
+          {:srt_server_conn, _address, "auth_stream"} -> :ok
         after
-          2_000 -> :timeout
+          2_000 -> :ok
         end
 
         Server.stop(server)
@@ -189,14 +153,15 @@ defmodule ExLibSRT.ClientServerCoopTest do
       Task.start(fn ->
         # No password
         assert {:ok, server} = Server.start("127.0.0.1", ctx.srt_port)
+        :ok = Server.add_stream_id_to_whitelist(server, "auth_stream")
         send(parent, :server_running)
 
-        receive do
-          {:srt_server_connect_request, _address, "auth_stream"} ->
-            Server.accept_awaiting_connect_request(server)
-        after
-          2_000 -> :timeout
-        end
+        :ok =
+          receive do
+            {:srt_server_conn, _address, "auth_stream"} -> :ok
+          after
+            2_000 -> :timeout
+          end
 
         Server.stop(server)
 
@@ -218,10 +183,8 @@ defmodule ExLibSRT.ClientServerCoopTest do
       Task.start(fn ->
         # No password
         assert {:ok, server} = Server.start("127.0.0.1", ctx.srt_port)
+        Server.add_stream_id_to_whitelist(server, "no_auth_stream")
         send(parent, :server_running)
-
-        assert_receive {:srt_server_connect_request, _address, "no_auth_stream"}
-        Server.accept_awaiting_connect_request(server)
 
         assert_receive {:srt_server_conn, _conn_id, _stream_id}, 1_000
 

--- a/test/ex_libsrt/client_server_coop_test.exs
+++ b/test/ex_libsrt/client_server_coop_test.exs
@@ -15,6 +15,7 @@ defmodule ExLibSRT.ClientServerCoopTest do
       send(parent, :running)
 
       assert_receive {:srt_server_conn, conn_id, _stream_id}, 1000
+      :ok = Server.bind_with_process(server, conn_id)
 
       assert_receive {:srt_server_conn_closed, ^conn_id}, 2000
 

--- a/test/ex_libsrt/client_server_coop_test.exs
+++ b/test/ex_libsrt/client_server_coop_test.exs
@@ -59,7 +59,7 @@ defmodule ExLibSRT.ClientServerCoopTest do
     assert {:error, "Stream rejected by server", 403} =
              Client.start("127.0.0.1", ctx.srt_port, "some_stream_id")
 
-    assert_receive :stopped, 2_000
+    assert_receive :stopped, 4_000
   end
 
   # Password authentication tests
@@ -115,7 +115,7 @@ defmodule ExLibSRT.ClientServerCoopTest do
       assert {:error, _reason, _code} =
                Client.start("127.0.0.1", ctx.srt_port, "auth_stream", client_password)
 
-      assert_receive :server_done, 2_000
+      assert_receive :server_done, 4_000
     end
 
     test "failed connection when server has password but client doesn't", ctx do
@@ -143,7 +143,7 @@ defmodule ExLibSRT.ClientServerCoopTest do
       assert {:error, _reason, _code} =
                Client.start("127.0.0.1", ctx.srt_port, "auth_stream")
 
-      assert_receive :server_done, 2_000
+      assert_receive :server_done, 4_000
     end
 
     test "failed connection when client has password but server doesn't", ctx do

--- a/test/ex_libsrt/client_server_coop_test.exs
+++ b/test/ex_libsrt/client_server_coop_test.exs
@@ -70,7 +70,7 @@ defmodule ExLibSRT.ClientServerCoopTest do
       parent = self()
 
       Task.start(fn ->
-        assert {:ok, server} = Server.start("127.0.0.1", ctx.srt_port, password)
+        assert {:ok, server} = Server.start("127.0.0.1", ctx.srt_port, password: password)
         Server.add_stream_id_to_whitelist(server, "auth_stream")
         send(parent, :server_running)
 
@@ -96,7 +96,7 @@ defmodule ExLibSRT.ClientServerCoopTest do
       parent = self()
 
       Task.start(fn ->
-        assert {:ok, server} = Server.start("127.0.0.1", ctx.srt_port, server_password)
+        assert {:ok, server} = Server.start("127.0.0.1", ctx.srt_port, password: server_password)
         send(parent, :server_running)
 
         receive do
@@ -124,7 +124,7 @@ defmodule ExLibSRT.ClientServerCoopTest do
       parent = self()
 
       Task.start(fn ->
-        assert {:ok, server} = Server.start("127.0.0.1", ctx.srt_port, server_password)
+        assert {:ok, server} = Server.start("127.0.0.1", ctx.srt_port, password: server_password)
         send(parent, :server_running)
 
         receive do

--- a/test/ex_libsrt/client_test.exs
+++ b/test/ex_libsrt/client_test.exs
@@ -48,8 +48,6 @@ defmodule ExLibSRT.ClientTest do
     assert_receive :srt_client_connected
 
     :ok = Client.stop(client)
-
-    assert {:error, "Client is not active"} = Client.send_data("test payload", client)
   end
 
   @tag :srt_tools_required
@@ -65,8 +63,6 @@ defmodule ExLibSRT.ClientTest do
     Transmit.stop_proxy(proxy)
 
     assert_receive :srt_client_disconnected, 500
-
-    assert {:error, "Client is not active"} = Client.send_data("some payload", client)
   end
 
   @tag :srt_tools_required

--- a/test/ex_libsrt/server_test.exs
+++ b/test/ex_libsrt/server_test.exs
@@ -256,9 +256,10 @@ defmodule ExLibSRT.ServerTest do
   describe "server owner" do
     @tag :srt_tools_required
     test "receives rejected client notifications" do
-      owner = spawn(fn ->
-        assert_receive {:srt_server_rejected_client, "unknown_stream_id"}, 1_000
-      end)
+      owner =
+        spawn(fn ->
+          assert_receive {:srt_server_rejected_client, "unknown_stream_id"}, 1_000
+        end)
 
       srt_port = Enum.random(10_000..20_000)
       udp_port = Enum.random(10_000..20_000)

--- a/test/ex_libsrt/server_test.exs
+++ b/test/ex_libsrt/server_test.exs
@@ -10,6 +10,7 @@ defmodule ExLibSRT.ServerTest do
     @tag :srt_tools_required
     test "accept a new connection", ctx do
       stream_id = "random_stream_id"
+      :ok = Server.add_stream_id_to_whitelist(ctx.server, stream_id)
 
       proxy =
         Transmit.start_streaming_proxy(
@@ -20,11 +21,6 @@ defmodule ExLibSRT.ServerTest do
 
       on_exit(fn -> stop_proxy_safe(proxy) end)
 
-      assert_receive {:srt_server_connect_request, address, ^stream_id}, 2_000
-      assert address == "127.0.0.1"
-
-      :ok = Server.accept_awaiting_connect_request(ctx.server)
-
       assert_receive {:srt_server_conn, _conn_id, ^stream_id}, 1_000
 
       Transmit.stop_proxy(proxy)
@@ -33,19 +29,18 @@ defmodule ExLibSRT.ServerTest do
     @tag :srt_tools_required
     test "decline the connection", ctx do
       stream_id = "forbidden_stream_id"
+      :ok = Server.add_stream_id_to_whitelist(ctx.server, "other_allowed_stream")
+
       proxy = Transmit.start_streaming_proxy(ctx.udp_port, ctx.srt_port, stream_id)
       on_exit(fn -> stop_proxy_safe(proxy) end)
-
-      assert_receive {:srt_server_connect_request, address, ^stream_id}, 2_000
-      assert address == "127.0.0.1"
-
-      Server.reject_awaiting_connect_request(ctx.server)
 
       refute_receive {:srt_server_conn, _conn_id, _stream_id}, 1_000
     end
 
     @tag :srt_tools_required
     test "receive data over connection", ctx do
+      :ok = Server.add_stream_id_to_whitelist(ctx.server, "data_stream_id")
+
       proxy =
         Transmit.start_streaming_proxy(ctx.udp_port, ctx.srt_port, "data_stream_id")
 
@@ -53,11 +48,6 @@ defmodule ExLibSRT.ServerTest do
 
       stream = Transmit.start_stream(ctx.udp_port)
       on_exit(fn -> close_stream_safe(stream) end)
-
-      assert_receive {:srt_server_connect_request, address, _stream_id}, 2_000
-      assert address == "127.0.0.1"
-
-      :ok = Server.accept_awaiting_connect_request(ctx.server)
 
       assert_receive {:srt_server_conn, conn_id, _stream_id}, 1_000
 
@@ -79,12 +69,11 @@ defmodule ExLibSRT.ServerTest do
     test "can handle multiple connections", ctx do
       streams =
         for udp_port <- ctx.udp_port..(ctx.udp_port + 10), into: %{} do
-          proxy = Transmit.start_streaming_proxy(udp_port, ctx.srt_port, "stream_#{udp_port}")
+          stream_id = "stream_#{udp_port}"
+          :ok = Server.add_stream_id_to_whitelist(ctx.server, stream_id)
+
+          proxy = Transmit.start_streaming_proxy(udp_port, ctx.srt_port, stream_id)
           on_exit(fn -> stop_proxy_safe(proxy) end)
-
-          assert_receive {:srt_server_connect_request, _address, _stream_id}, 2_000
-
-          :ok = Server.accept_awaiting_connect_request(ctx.server)
 
           assert_receive {:srt_server_conn, conn_id, _stream_id}, 1_000
 
@@ -116,10 +105,7 @@ defmodule ExLibSRT.ServerTest do
 
       on_exit(fn -> stop_proxy_safe(proxy) end)
 
-      assert_receive {:srt_server_connect_request, _address, _stream_id}, 2_000
-      :ok = Server.accept_awaiting_connect_request(ctx.server)
-
-      assert_receive {:srt_server_conn, conn_id, _stream_id}, 1_000
+      assert_receive {:srt_server_conn, conn_id, _stream_id}, 2_000
 
       :ok = Transmit.stop_proxy(proxy)
 
@@ -128,57 +114,23 @@ defmodule ExLibSRT.ServerTest do
 
     @tag :srt_tools_required
     test "close an ongoing connection", ctx do
+      stream_id = "stream_id"
+      Server.add_stream_id_to_whitelist(ctx.server, stream_id)
+
       proxy =
         Transmit.start_streaming_proxy(
           ctx.udp_port,
-          ctx.srt_port
+          ctx.srt_port,
+          stream_id
         )
 
       on_exit(fn -> stop_proxy_safe(proxy) end)
 
-      assert_receive {:srt_server_connect_request, _address, _stream_id}, 2_000
-      :ok = Server.accept_awaiting_connect_request(ctx.server)
-
-      assert_receive {:srt_server_conn, conn_id, _stream_id}, 1_000
+      assert_receive {:srt_server_conn, conn_id, ^stream_id}, 2_000
 
       Server.close_server_connection(conn_id, ctx.server)
 
       assert_receive {:srt_server_conn_closed, ^conn_id}, 1_000
-    end
-
-    @tag :srt_tools_required
-    test "read socket stats", ctx do
-      proxy =
-        Transmit.start_streaming_proxy(
-          ctx.udp_port,
-          ctx.srt_port
-        )
-
-      on_exit(fn -> stop_proxy_safe(proxy) end)
-
-      assert_receive {:srt_server_connect_request, _address, _stream_id}, 2_000
-      :ok = Server.accept_awaiting_connect_request(ctx.server)
-
-      assert_receive {:srt_server_conn, conn_id, _stream_id}, 1_000
-
-      stream = Transmit.start_stream(ctx.udp_port)
-      on_exit(fn -> close_stream_safe(stream) end)
-
-      payload = :crypto.strong_rand_bytes(100)
-
-      for _i <- 1..10 do
-        :ok = Transmit.send_payload(stream, payload)
-
-        assert_receive {:srt_data, ^conn_id, ^payload}, 1_000
-      end
-
-      assert {:ok, stats} = Server.read_socket_stats(conn_id, ctx.server)
-
-      assert %ExLibSRT.SocketStats{} = stats
-      assert stats.pktRecv == 10
-      assert stats.byteRecvTotal > 1_000
-
-      assert {:error, "Socket not found"} = Server.read_socket_stats(2137, ctx.server)
     end
 
     @tag :srt_tools_required
@@ -215,6 +167,8 @@ defmodule ExLibSRT.ServerTest do
         end
       end
 
+      :ok = Server.add_stream_id_to_whitelist(ctx.server, "data_stream_id")
+
       proxy =
         Transmit.start_streaming_proxy(ctx.udp_port, ctx.srt_port, "data_stream_id")
 
@@ -223,15 +177,11 @@ defmodule ExLibSRT.ServerTest do
       stream = Transmit.start_stream(ctx.udp_port)
       on_exit(fn -> close_stream_safe(stream) end)
 
-      assert_receive {:srt_server_connect_request, address, _stream_id}, 2_000
-      assert address == "127.0.0.1"
+      assert_receive {:srt_server_conn, conn_id, stream_id}, 2_000
 
-      assert {:ok, connection} =
-               Server.accept_awaiting_connect_request_with_handler(ReceiverHandler, ctx.server)
+      {:ok, connection} = ExLibSRT.Connection.start(ReceiverHandler)
+      send(connection, {:srt_server_conn, conn_id, stream_id})
 
-      assert is_pid(connection)
-
-      refute_receive {:srt_server_conn, _conn_id, _stream_id}, 1_000
       assert_receive {:srt_handler_connected, _conn_id, _stream_id}, 1_000
 
       for i <- 1..10 do
@@ -241,14 +191,49 @@ defmodule ExLibSRT.ServerTest do
       :ok = Transmit.close_stream(stream)
 
       for i <- 1..10 do
+        assert_receive {:srt_data, ^conn_id, data}, 500
+        send(connection, {:srt_data, conn_id, data})
         assert_receive {:srt_handler_data, payload}, 500
         assert payload == "Hello world! (#{i})"
       end
 
       Transmit.stop_proxy(proxy)
 
-      refute_receive {:srt_server_conn_closed, _conn_id}, 1_000
+      assert_receive {:srt_server_conn_closed, ^conn_id}, 1_000
+      send(connection, {:srt_server_conn_closed, conn_id})
       assert_receive :srt_handler_disconnected, 1_000
+    end
+
+    @tag :srt_tools_required
+    test "read socket stats", ctx do
+      proxy =
+        Transmit.start_streaming_proxy(
+          ctx.udp_port,
+          ctx.srt_port
+        )
+
+      on_exit(fn -> stop_proxy_safe(proxy) end)
+
+      assert_receive {:srt_server_conn, conn_id, _stream_id}, 2_000
+
+      stream = Transmit.start_stream(ctx.udp_port)
+      on_exit(fn -> close_stream_safe(stream) end)
+
+      payload = :crypto.strong_rand_bytes(100)
+
+      for _i <- 1..10 do
+        :ok = Transmit.send_payload(stream, payload)
+
+        assert_receive {:srt_data, ^conn_id, ^payload}, 1_000
+      end
+
+      assert {:ok, stats} = Server.read_socket_stats(conn_id, ctx.server)
+
+      assert %ExLibSRT.SocketStats{} = stats
+      assert stats.pktRecv == 10
+      assert stats.byteRecvTotal > 1_000
+
+      assert {:error, "Socket not found"} = Server.read_socket_stats(2137, ctx.server)
     end
   end
 

--- a/test/ex_libsrt/server_test.exs
+++ b/test/ex_libsrt/server_test.exs
@@ -96,6 +96,8 @@ defmodule ExLibSRT.ServerTest do
 
     @tag :srt_tools_required
     test "send closed connection notification", ctx do
+      :ok = Server.add_stream_id_to_whitelist(ctx.server, "closing_stream_id")
+
       proxy =
         Transmit.start_streaming_proxy(
           ctx.udp_port,
@@ -206,10 +208,13 @@ defmodule ExLibSRT.ServerTest do
 
     @tag :srt_tools_required
     test "read socket stats", ctx do
+      :ok = Server.add_stream_id_to_whitelist(ctx.server, "stats_stream_id")
+
       proxy =
         Transmit.start_streaming_proxy(
           ctx.udp_port,
-          ctx.srt_port
+          ctx.srt_port,
+          "stats_stream_id"
         )
 
       on_exit(fn -> stop_proxy_safe(proxy) end)

--- a/test/ex_libsrt/server_test.exs
+++ b/test/ex_libsrt/server_test.exs
@@ -253,6 +253,26 @@ defmodule ExLibSRT.ServerTest do
     end
   end
 
+  describe "server owner" do
+    @tag :srt_tools_required
+    test "receives rejected client notifications" do
+      owner = spawn(fn ->
+        assert_receive {:srt_server_rejected_client, "unknown_stream_id"}, 1_000
+      end)
+
+      srt_port = Enum.random(10_000..20_000)
+      udp_port = Enum.random(10_000..20_000)
+
+      {:ok, server} = Server.start("0.0.0.0", srt_port, "", -1, [], owner)
+      on_exit(fn -> Server.stop(server) end)
+
+      proxy = Transmit.start_streaming_proxy(udp_port, srt_port, "unknown_stream_id")
+      on_exit(fn -> stop_proxy_safe(proxy) end)
+
+      refute_receive {:srt_server_rejected_client, _stream_id}, 0
+    end
+  end
+
   # Password validation tests
   describe "server password validation" do
     test "rejects too short password" do

--- a/test/ex_libsrt/server_test.exs
+++ b/test/ex_libsrt/server_test.exs
@@ -190,7 +190,7 @@ defmodule ExLibSRT.ServerTest do
 
       assert_receive {:srt_server_conn, conn_id, _stream_id}, 2_000
 
-      {:ok, _connection} = Server.bind_with_handler(ReceiverHandler, ctx.server, conn_id)
+      {:ok, _connection} = Server.bind_with_handler(ctx.server, conn_id, ReceiverHandler)
 
       for i <- 1..10 do
         :ok = Transmit.send_payload(stream, "Hello world! (#{i})")
@@ -266,6 +266,33 @@ defmodule ExLibSRT.ServerTest do
     end
   end
 
+  describe "accept-all mode" do
+    setup :prepare_streaming_accept_all
+
+    @tag :srt_tools_required
+    test "accepts any connection regardless of stream id", ctx do
+      proxy = Transmit.start_streaming_proxy(ctx.udp_port, ctx.srt_port, "any_stream_id")
+      on_exit(fn -> stop_proxy_safe(proxy) end)
+
+      assert_receive {:srt_server_conn, conn_id, "any_stream_id"}, 1_000
+      :ok = Server.bind_with_process(ctx.server, conn_id)
+
+      Transmit.stop_proxy(proxy)
+    end
+
+    @tag :srt_tools_required
+    test "notifies owner and drops connection if not bound within 1 second", ctx do
+      proxy = Transmit.start_streaming_proxy(ctx.udp_port, ctx.srt_port, "unbound_stream")
+      on_exit(fn -> stop_proxy_safe(proxy) end)
+
+      assert_receive {:srt_server_conn, conn_id, "unbound_stream"}, 1_000
+
+      assert_receive {:srt_server_conn_timeout, ^conn_id, "unbound_stream"}, 2_000
+
+      assert {:error, _reason} = Server.bind_with_process(ctx.server, conn_id)
+    end
+  end
+
   # Password validation tests
   describe "server password validation" do
     test "rejects too short password" do
@@ -305,6 +332,16 @@ defmodule ExLibSRT.ServerTest do
     srt_port = Enum.random(10_000..20_000)
 
     {:ok, server} = Server.start("0.0.0.0", srt_port)
+    on_exit(fn -> Server.stop(server) end)
+
+    [udp_port: udp_port, srt_port: srt_port, server: server]
+  end
+
+  defp prepare_streaming_accept_all(_ctx) do
+    udp_port = Enum.random(10_000..20_000)
+    srt_port = Enum.random(10_000..20_000)
+
+    {:ok, server} = Server.start("0.0.0.0", srt_port, "", -1, nil)
     on_exit(fn -> Server.stop(server) end)
 
     [udp_port: udp_port, srt_port: srt_port, server: server]

--- a/test/ex_libsrt/server_test.exs
+++ b/test/ex_libsrt/server_test.exs
@@ -21,7 +21,8 @@ defmodule ExLibSRT.ServerTest do
 
       on_exit(fn -> stop_proxy_safe(proxy) end)
 
-      assert_receive {:srt_server_conn, _conn_id, ^stream_id}, 1_000
+      assert_receive {:srt_server_conn, conn_id, ^stream_id}, 1_000
+      :ok = Server.bind_with_process(ctx.server, conn_id)
 
       Transmit.stop_proxy(proxy)
     end
@@ -61,6 +62,7 @@ defmodule ExLibSRT.ServerTest do
       on_exit(fn -> close_stream_safe(stream) end)
 
       assert_receive {:srt_server_conn, conn_id, _stream_id}, 1_000
+      :ok = Server.bind_with_process(ctx.server, conn_id)
 
       for i <- 1..10 do
         :ok = Transmit.send_payload(stream, "Hello world! (#{i})")
@@ -87,6 +89,7 @@ defmodule ExLibSRT.ServerTest do
           on_exit(fn -> stop_proxy_safe(proxy) end)
 
           assert_receive {:srt_server_conn, conn_id, _stream_id}, 1_000
+          :ok = Server.bind_with_process(ctx.server, conn_id)
 
           stream = Transmit.start_stream(udp_port)
           on_exit(fn -> close_stream_safe(stream) end)
@@ -119,6 +122,7 @@ defmodule ExLibSRT.ServerTest do
       on_exit(fn -> stop_proxy_safe(proxy) end)
 
       assert_receive {:srt_server_conn, conn_id, _stream_id}, 2_000
+      :ok = Server.bind_with_process(ctx.server, conn_id)
 
       :ok = Transmit.stop_proxy(proxy)
 
@@ -140,6 +144,7 @@ defmodule ExLibSRT.ServerTest do
       on_exit(fn -> stop_proxy_safe(proxy) end)
 
       assert_receive {:srt_server_conn, conn_id, ^stream_id}, 2_000
+      :ok = Server.bind_with_process(ctx.server, conn_id)
 
       Server.close_server_connection(conn_id, ctx.server)
 
@@ -190,10 +195,9 @@ defmodule ExLibSRT.ServerTest do
       stream = Transmit.start_stream(ctx.udp_port)
       on_exit(fn -> close_stream_safe(stream) end)
 
-      assert_receive {:srt_server_conn, conn_id, stream_id}, 2_000
+      assert_receive {:srt_server_conn, conn_id, _stream_id}, 2_000
 
-      {:ok, connection} = ExLibSRT.Connection.start(ReceiverHandler)
-      send(connection, {:srt_server_conn, conn_id, stream_id})
+      {:ok, _connection} = Server.bind_with_handler(ReceiverHandler, ctx.server, conn_id)
 
       assert_receive {:srt_handler_connected, _conn_id, _stream_id}, 1_000
 
@@ -204,16 +208,12 @@ defmodule ExLibSRT.ServerTest do
       :ok = Transmit.close_stream(stream)
 
       for i <- 1..10 do
-        assert_receive {:srt_data, ^conn_id, data}, 500
-        send(connection, {:srt_data, conn_id, data})
         assert_receive {:srt_handler_data, payload}, 500
         assert payload == "Hello world! (#{i})"
       end
 
       Transmit.stop_proxy(proxy)
 
-      assert_receive {:srt_server_conn_closed, ^conn_id}, 1_000
-      send(connection, {:srt_server_conn_closed, conn_id})
       assert_receive :srt_handler_disconnected, 1_000
     end
 
@@ -231,6 +231,7 @@ defmodule ExLibSRT.ServerTest do
       on_exit(fn -> stop_proxy_safe(proxy) end)
 
       assert_receive {:srt_server_conn, conn_id, _stream_id}, 2_000
+      :ok = Server.bind_with_process(ctx.server, conn_id)
 
       stream = Transmit.start_stream(ctx.udp_port)
       on_exit(fn -> close_stream_safe(stream) end)
@@ -264,7 +265,7 @@ defmodule ExLibSRT.ServerTest do
       srt_port = Enum.random(10_000..20_000)
       udp_port = Enum.random(10_000..20_000)
 
-      {:ok, server} = Server.start("0.0.0.0", srt_port, "", -1, [], owner)
+      {:ok, server} = Server.start("0.0.0.0", srt_port, "", -1, ["some_allowed_stream"], owner)
       on_exit(fn -> Server.stop(server) end)
 
       proxy = Transmit.start_streaming_proxy(udp_port, srt_port, "unknown_stream_id")

--- a/test/ex_libsrt/server_test.exs
+++ b/test/ex_libsrt/server_test.exs
@@ -38,6 +38,17 @@ defmodule ExLibSRT.ServerTest do
     end
 
     @tag :srt_tools_required
+    test "notifies about rejected connection", ctx do
+      stream_id = "forbidden_stream_id"
+      :ok = Server.add_stream_id_to_whitelist(ctx.server, "other_allowed_stream")
+
+      proxy = Transmit.start_streaming_proxy(ctx.udp_port, ctx.srt_port, stream_id)
+      on_exit(fn -> stop_proxy_safe(proxy) end)
+
+      assert_receive {:srt_server_rejected_client, ^stream_id}, 1_000
+    end
+
+    @tag :srt_tools_required
     test "receive data over connection", ctx do
       :ok = Server.add_stream_id_to_whitelist(ctx.server, "data_stream_id")
 

--- a/test/ex_libsrt/server_test.exs
+++ b/test/ex_libsrt/server_test.exs
@@ -164,13 +164,6 @@ defmodule ExLibSRT.ServerTest do
         end
 
         @impl true
-        def handle_connected(conn_id, stream_id, receiver) do
-          send(receiver, {:srt_handler_connected, conn_id, stream_id})
-
-          {:ok, receiver}
-        end
-
-        @impl true
         def handle_disconnected(receiver) do
           send(receiver, :srt_handler_disconnected)
 
@@ -198,8 +191,6 @@ defmodule ExLibSRT.ServerTest do
       assert_receive {:srt_server_conn, conn_id, _stream_id}, 2_000
 
       {:ok, _connection} = Server.bind_with_handler(ReceiverHandler, ctx.server, conn_id)
-
-      assert_receive {:srt_handler_connected, _conn_id, _stream_id}, 1_000
 
       for i <- 1..10 do
         :ok = Transmit.send_payload(stream, "Hello world! (#{i})")

--- a/test/ex_libsrt/server_test.exs
+++ b/test/ex_libsrt/server_test.exs
@@ -256,7 +256,12 @@ defmodule ExLibSRT.ServerTest do
       srt_port = Enum.random(10_000..20_000)
       udp_port = Enum.random(10_000..20_000)
 
-      {:ok, server} = Server.start("0.0.0.0", srt_port, "", -1, ["some_allowed_stream"], owner)
+      {:ok, server} =
+        Server.start("0.0.0.0", srt_port,
+          accept_mode: {:whitelist, ["some_allowed_stream"]},
+          owner: owner
+        )
+
       on_exit(fn -> Server.stop(server) end)
 
       proxy = Transmit.start_streaming_proxy(udp_port, srt_port, "unknown_stream_id")
@@ -297,25 +302,25 @@ defmodule ExLibSRT.ServerTest do
   describe "server password validation" do
     test "rejects too short password" do
       assert {:error, "SRT password must be at least 10 characters long", 0} =
-               Server.start_link("127.0.0.1", 8080, "short")
+               Server.start_link("127.0.0.1", 8080, password: "short")
     end
 
     test "rejects too long password" do
       long_password = String.duplicate("a", 80)
 
       assert {:error, "SRT password must be at most 79 characters long", 0} =
-               Server.start_link("127.0.0.1", 8080, long_password)
+               Server.start_link("127.0.0.1", 8080, password: long_password)
     end
 
     test "accepts valid password length" do
       valid_password = "validpassword123"
-      {:ok, server} = Server.start_link("127.0.0.1", 8080, valid_password)
+      {:ok, server} = Server.start_link("127.0.0.1", 8080, password: valid_password)
       assert is_pid(server)
       Server.stop(server)
     end
 
     test "accepts empty password (no auth)" do
-      {:ok, server} = Server.start_link("127.0.0.1", 8080, "")
+      {:ok, server} = Server.start_link("127.0.0.1", 8080, password: "")
       assert is_pid(server)
       Server.stop(server)
     end
@@ -341,7 +346,7 @@ defmodule ExLibSRT.ServerTest do
     udp_port = Enum.random(10_000..20_000)
     srt_port = Enum.random(10_000..20_000)
 
-    {:ok, server} = Server.start("0.0.0.0", srt_port, "", -1, nil)
+    {:ok, server} = Server.start("0.0.0.0", srt_port, accept_mode: :accept_all)
     on_exit(fn -> Server.stop(server) end)
 
     [udp_port: udp_port, srt_port: srt_port, server: server]


### PR DESCRIPTION
This PR:
1. Removes `ExLibSRT.Server.accept_awaiting_connection()` and  `ExLibSRT.Server.accept_awaiting_connection_with_handler()` in favour of providing a whitelist of `stream_id`s or working in "accept-all" mode..
2. Adds `ExLibSRT.Server.bind_with_process` and `ExLibSRT.Server.bind_with_handler()` functions to bind stream data receiver
3. Adds `srt_server_rejected_client` and `srt_server_conn_timeout` notifications, which are sent to the `owner` process (specified at `Server.start()` or `Server.start_link()`)

It removes a need to wait for acceptance or rejection of a connection on the SRT's receiver thread, which blocks all the traffic to the server. 
Decision to introduce this change was dictated by the fact that:
* the decision whether or not to accept the connection needs to be done instantly, as stated [here](https://github.com/Haivision/srt/issues/2282)
* we cannot rely on custom client's behaviour (as suggested e.g. [here](https://github.com/Haivision/srt/issues/3178#issuecomment-2948563459))
* in most real life use cases the desired stream ids is known a priori to the connection (as it needs to be e.g. exchanges between the client and the server via external channel)

TODO:
- [x] add a message sent from the server to the "controlling process" (e.g. the one that started the server) that a connection attempt was made, but it was rejected since its `stream_id` wasn't in the whitelist - the "controlling process" can then e.g. decide to add the `stream_id` to the whitelist and hope that the client reconnects
- [x] figure out how to handle a behaviour when the server wants to accept all the connections, independent of what `stream_id` they are assigned - "accept-all" mode was added
- [x] add a mutex guarding whitelist and the `stream_id -> receiver_pid` map