### PR TITLE
Fix Release workflow startup_failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,14 @@ on:
       - "v*"
   workflow_dispatch:
 
+# The github-release reusable workflow requires `contents: write` to create the
+# GitHub release. This repository's default workflow token permission is
+# read-only, so without an explicit grant here GitHub rejects the workflow at
+# load time (startup_failure). Declaring it explicitly makes the workflow start
+# regardless of the repository's default token permission setting.
+permissions:
+  contents: write
+
 jobs:
   build_test:
     uses: membraneframework/membrane_actions/.github/workflows/build-test.yml@main


### PR DESCRIPTION
## Problem

The `Release` workflow (run [28377643660](https://github.com/membraneframework/ex_libsrt/actions/runs/28377643660), triggered by tag `v0.2.1`) concluded `startup_failure`: GitHub rejected the workflow at load time and ran **zero jobs**, so nothing was published to Hex.

## Root cause

The `gh_release` job calls the reusable workflow `membraneframework/membrane_actions/.github/workflows/github-release.yml@main`, which declares job-level `permissions: contents: write` (required to create the GitHub release).

This repository's **default workflow token permission is `read`** (`gh api repos/membraneframework/ex_libsrt/actions/permissions/workflow` -> `"default_workflow_permissions":"read"`), and `release.yml` had **no `permissions:` block**. A called reusable workflow may not request more permission than the caller token's maximum, so GitHub rejected the entire workflow before starting.

Evidence:
- The `CI` workflow succeeds at the same commit (`511c79d`) because its reusable workflows (build-test / test / lint) only need `contents: read`.
- The sibling repo `membrane_rtp_plugin`, whose Release publishes fine, has an identically-structured `release.yml` but its repo default token permission is `write` (`"default_workflow_permissions":"write"`), so it never hits this ceiling.
- All `uses:` refs resolve at `@main`; the YAML is valid. The failure was purely the permission ceiling, not a bad ref or syntax error.

## Fix

Add an explicit top-level `permissions: contents: write` block to `release.yml`. This makes the workflow start regardless of the repo's default token setting. Each reusable workflow still re-declares its own narrower `permissions`, so the test/lint/build/publish jobs remain effectively read-only; only `github-release.yml` uses the write scope.

## Verification

- YAML validated (parses cleanly; `permissions: {contents: write}`).
- All referenced reusable workflows confirmed to exist at `@main`.
- **Note:** the Release workflow only triggers on **tag push**, so this PR's CI does **not** exercise it. Final confirmation requires pushing a new tag, which is intentionally deferred to a human reviewer. Do not merge/tag/publish without review.